### PR TITLE
Add Spot price support

### DIFF
--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -13,7 +13,7 @@ function setupDom() {
     <input id="qty-0" />
     <input type="radio" name="side1-0" value="buy" checked>
     <input type="radio" name="side1-0" value="sell">
-    <select id="type1-0"><option value="AVG">AVG</option><option value="Fix">Fix</option></select>
+    <select id="type1-0"><option value="AVG">AVG</option><option value="Fix">Fix</option><option value="Spot">Spot</option></select>
     <select id="month1-0"><option>January</option><option>February</option></select>
     <select id="year1-0"><option>2025</option></select>
     <input type="radio" name="side2-0" value="buy">
@@ -59,6 +59,15 @@ describe('generateRequest', () => {
     generateRequest(0);
     const out = document.getElementById('output-0').textContent;
     expect(out).toBe('LME Request: Buy 7 mt Al AVG January 2025 Flat and Sell 7 mt Al C2R 02-01-25 ppt 06-01-25 against');
+  });
+
+  test('creates Spot request text', () => {
+    document.getElementById('qty-0').value = '8';
+    document.getElementById('type1-0').value = 'Spot';
+    generateRequest(0);
+    const ppt = getFixPpt(calendarUtils.formatDate(new Date()));
+    const out = document.getElementById('output-0').textContent;
+    expect(out).toBe(`LME Request: Buy 8 mt Al Spot ppt ${ppt} against`);
   });
 
   test('shows error for non-numeric quantity', () => {

--- a/index.html
+++ b/index.html
@@ -46,9 +46,10 @@
           <label><input type="radio" name="side1-0" value="sell" class="mr-1"/> Sell</label><br />
           <div class="flex items-center gap-2 mt-2 mb-2">
             <label class="font-medium">Price Type:</label>
-            <select id="type1-0" class="form-control w-32">
+            <select id="type1-0" class="form-control w-32" onchange="toggleLeg2(0)">
               <option value="AVG">AVG</option>
               <option value="Fix">Fix</option>
+              <option value="Spot">Spot</option>
             </select>
           </div>
           <div class="flex gap-2">
@@ -68,7 +69,7 @@
             </div>
           </div>
         </div>
-        <div>
+        <div id="leg2-0">
           <h2 class="font-semibold">Leg 2</h2>
           <label><input type="radio" name="side2-0" value="buy" checked class="mr-1"/> Buy</label>
           <label><input type="radio" name="side2-0" value="sell" class="mr-1"/> Sell</label><br />


### PR DESCRIPTION
## Summary
- add `Spot` price type in Leg 1 form
- disable Leg 2 when Spot is selected
- generate correct Spot trade text
- test for Spot output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68413d789f54832ead8336f9b8786794