### PR TITLE
Add AVG Inter option for leg 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Make sure to visit the full path to `index.html` (not just `/`) because the serv
 Enter quantities as finite positive numbers. Values of zero or negative amounts
 will trigger an error message.
 
+When selecting the price type for Leg 1 you can choose **AVG Inter** to specify an averaging period. Pick a start and end date in the Leg 1 section and the request text will reflect that range.
+
 ## Building
 
 No build step is required. The repository only contains static files (`index.html`, `main.js`, `manifest.json` and `service-worker.js`). If you modify the code you simply refresh the browser to see the changes.

--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -13,13 +13,15 @@ function setupDom() {
     <input id="qty-0" />
     <input type="radio" name="side1-0" value="buy" checked>
     <input type="radio" name="side1-0" value="sell">
-    <select id="type1-0"><option value="AVG">AVG</option><option value="Fix">Fix</option></select>
-    <select id="month1-0"><option>January</option><option>February</option></select>
+    <select id="type1-0"><option value="AVG">AVG</option><option value="AVGInter">AVG Inter</option><option value="Fix">Fix</option></select>
+    <select id="month1-0"><option>January</option><option>February</option><option>October</option></select>
     <select id="year1-0"><option>2025</option></select>
+    <input id="startDate-0" type="date" />
+    <input id="endDate-0" type="date" />
     <input type="radio" name="side2-0" value="buy">
     <input type="radio" name="side2-0" value="sell" checked>
     <select id="type2-0"><option value="Fix">Fix</option><option value="C2R">C2R</option><option value="AVG">AVG</option></select>
-    <select id="month2-0"><option>February</option></select>
+    <select id="month2-0"><option>February</option><option>October</option></select>
     <select id="year2-0"><option>2025</option></select>
     <input id="fixDate-0" />
     <input type="checkbox" id="samePpt-0" />
@@ -59,6 +61,19 @@ describe('generateRequest', () => {
     generateRequest(0);
     const out = document.getElementById('output-0').textContent;
     expect(out).toBe('LME Request: Buy 7 mt Al AVG January 2025 Flat and Sell 7 mt Al C2R 02-01-25 ppt 06-01-25 against');
+  });
+
+  test('creates AVGInter request text', () => {
+    document.getElementById('qty-0').value = '5';
+    document.getElementById('type1-0').value = 'AVGInter';
+    document.getElementById('startDate-0').value = '2025-09-01';
+    document.getElementById('endDate-0').value = '2025-09-10';
+    document.getElementById('type2-0').value = 'AVG';
+    document.getElementById('month2-0').value = 'October';
+    document.getElementById('year2-0').value = '2025';
+    generateRequest(0);
+    const out = document.getElementById('output-0').textContent;
+    expect(out).toBe('LME Request: Buy 5 mt Al AVG (01-09-25 \u2013 10-09-25) and Sell 5 mt Al AVG October 2025 Flat against');
   });
 
   test('shows error for non-numeric quantity', () => {

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
             <label class="font-medium">Price Type:</label>
             <select id="type1-0" class="form-control w-32">
               <option value="AVG">AVG</option>
+              <option value="AVGInter">AVG Inter</option>
               <option value="Fix">Fix</option>
             </select>
           </div>
@@ -65,6 +66,16 @@
               <select id="year1-0" class="form-control w-28">
                 <!-- Options populated via JavaScript -->
               </select>
+            </div>
+          </div>
+          <div class="flex gap-2 mt-2">
+            <div>
+              <label class="block mb-1">Start Date:</label>
+              <input type="date" id="startDate-0" class="form-control w-36" />
+            </div>
+            <div>
+              <label class="block mb-1">End Date:</label>
+              <input type="date" id="endDate-0" class="form-control w-36" />
             </div>
           </div>
         </div>

--- a/main.js
+++ b/main.js
@@ -120,28 +120,37 @@ const leg1Side = document.querySelector(`input[name='side1-${index}']:checked`).
 const leg1Type = document.getElementById(`type1-${index}`)?.value || 'AVG';
 const month = document.getElementById(`month1-${index}`).value;
 const year = parseInt(document.getElementById(`year1-${index}`).value);
+const startDateRaw = document.getElementById(`startDate-${index}`)?.value || '';
+const endDateRaw = document.getElementById(`endDate-${index}`)?.value || '';
 const leg2Side = document.querySelector(`input[name='side2-${index}']:checked`).value;
 const leg2Type = document.getElementById(`type2-${index}`).value;
+const month2 = document.getElementById(`month2-${index}`).value;
+const year2 = parseInt(document.getElementById(`year2-${index}`).value);
 const fixInput = document.getElementById(`fixDate-${index}`);
 const dateFixRaw = fixInput.value;
 const dateFix = dateFixRaw ? formatDate(parseInputDate(dateFixRaw)) : '';
 fixInput.classList.remove('border-red-500');
 const useSamePPT = document.getElementById(`samePpt-${index}`).checked;
-const monthIndex = new Date(`${month} 1, ${year}`).getMonth();
-const pptDateAVG = getSecondBusinessDay(year, monthIndex);
+const monthIndex = new Date(`${month2} 1, ${year2}`).getMonth();
+const pptDateAVG = getSecondBusinessDay(year2, monthIndex);
 
 let leg1;
 if (leg1Type === 'AVG') {
   leg1 = `${capitalize(leg1Side)} ${q} mt Al AVG ${month} ${year} Flat`;
+} else if (leg1Type === 'AVGInter') {
+  const start = parseInputDate(startDateRaw);
+  const end = parseInputDate(endDateRaw);
+  if (!start || !end) throw new Error('Start and end dates are required for AVG Inter.');
+  const startStr = formatDate(start);
+  const endStr = formatDate(end);
+  leg1 = `${capitalize(leg1Side)} ${q} mt Al AVG (${startStr} – ${endStr})`;
 } else {
   const pptFixLeg1 = getFixPpt(dateFix);
   leg1 = `${capitalize(leg1Side)} ${q} mt Al Fix ppt ${pptFixLeg1}`;
 }
 let leg2;
 if (leg2Type === 'AVG') {
-const month2 = document.getElementById(`month2-${index}`).value;
-const year2 = parseInt(document.getElementById(`year2-${index}`).value);
-leg2 = `${capitalize(leg2Side)} ${q} mt Al AVG ${month2} ${year2} Flat`;
+  leg2 = `${capitalize(leg2Side)} ${q} mt Al AVG ${month2} ${year2} Flat`;
 } else if (leg2Type === 'Fix') {
   let pptFix;
   if (useSamePPT) {


### PR DESCRIPTION
## Summary
- support `AVGInter` option for leg 1 price type
- clone `Start Date`/`End Date` inputs when adding new trades
- compute PPT date from leg 2 month
- handle `AVGInter` in request generator
- test new `AVGInter` behaviour
- document new option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684140f5d330832eb8f398335ac08987