### PR TITLE
Add AVG Inter toggle for Leg1 fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Make sure to visit the full path to `index.html` (not just `/`) because the serv
 Enter quantities as finite positive numbers. Values of zero or negative amounts
 will trigger an error message.
 
+Selecting **AVG Inter** as the Leg 1 price type hides the month/year dropdowns
+and instead shows start and end date inputs for that leg.
+
 ## Building
 
 No build step is required. The repository only contains static files (`index.html`, `main.js`, `manifest.json` and `service-worker.js`). If you modify the code you simply refresh the browser to see the changes.

--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -3,28 +3,36 @@
 const calendarUtils = require('../calendar-utils');
 global.calendarUtils = calendarUtils;
 
-const { getSecondBusinessDay, getFixPpt, generateRequest } = require('../main');
+const { getSecondBusinessDay, getFixPpt, generateRequest, updateLeg1Fields } = require('../main');
 
 document.body.innerHTML = '<select id="calendarType"></select>';
 document.getElementById('calendarType').value = 'gregorian';
 
 function setupDom() {
   document.body.innerHTML += `
-    <input id="qty-0" />
-    <input type="radio" name="side1-0" value="buy" checked>
-    <input type="radio" name="side1-0" value="sell">
-    <select id="type1-0"><option value="AVG">AVG</option><option value="Fix">Fix</option></select>
-    <select id="month1-0"><option>January</option><option>February</option></select>
-    <select id="year1-0"><option>2025</option></select>
-    <input type="radio" name="side2-0" value="buy">
-    <input type="radio" name="side2-0" value="sell" checked>
-    <select id="type2-0"><option value="Fix">Fix</option><option value="C2R">C2R</option><option value="AVG">AVG</option></select>
-    <select id="month2-0"><option>February</option></select>
-    <select id="year2-0"><option>2025</option></select>
-    <input id="fixDate-0" />
-    <input type="checkbox" id="samePpt-0" />
-    <p id="output-0"></p>
-    <textarea id="final-output"></textarea>
+    <div id="trade-0">
+      <input id="qty-0" />
+      <input type="radio" name="side1-0" value="buy" checked>
+      <input type="radio" name="side1-0" value="sell">
+      <select id="type1-0"><option value="AVG">AVG</option><option value="Fix">Fix</option><option value="AVGInter">AVGInter</option></select>
+      <div class="leg1-month-year">
+        <select id="month1-0"><option>January</option><option>February</option></select>
+        <select id="year1-0"><option>2025</option></select>
+      </div>
+      <div class="leg1-date-range hidden">
+        <input id="startDate1-0" />
+        <input id="endDate1-0" />
+      </div>
+      <input type="radio" name="side2-0" value="buy">
+      <input type="radio" name="side2-0" value="sell" checked>
+      <select id="type2-0"><option value="Fix">Fix</option><option value="C2R">C2R</option><option value="AVG">AVG</option></select>
+      <select id="month2-0"><option>February</option></select>
+      <select id="year2-0"><option>2025</option></select>
+      <input id="fixDate-0" />
+      <input type="checkbox" id="samePpt-0" />
+      <p id="output-0"></p>
+      <textarea id="final-output"></textarea>
+    </div>
   `;
 }
 
@@ -84,6 +92,28 @@ describe('generateRequest', () => {
     generateRequest(0);
     const out = document.getElementById('output-0').textContent;
     expect(out).toBe('Please provide a fixing date.');
+  });
+});
+
+describe('updateLeg1Fields', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<select id="calendarType"></select>';
+    document.getElementById('calendarType').value = 'gregorian';
+    setupDom();
+  });
+
+  test('toggles month and date inputs', () => {
+    const sel = document.getElementById('type1-0');
+    const monthYear = document.querySelector('.leg1-month-year');
+    const dateRange = document.querySelector('.leg1-date-range');
+    sel.value = 'AVGInter';
+    updateLeg1Fields(0);
+    expect(monthYear.classList.contains('hidden')).toBe(true);
+    expect(dateRange.classList.contains('hidden')).toBe(false);
+    sel.value = 'AVG';
+    updateLeg1Fields(0);
+    expect(monthYear.classList.contains('hidden')).toBe(false);
+    expect(dateRange.classList.contains('hidden')).toBe(true);
   });
 });
 

--- a/index.html
+++ b/index.html
@@ -49,9 +49,10 @@
             <select id="type1-0" class="form-control w-32">
               <option value="AVG">AVG</option>
               <option value="Fix">Fix</option>
+              <option value="AVGInter">AVG Inter</option>
             </select>
           </div>
-          <div class="flex gap-2">
+          <div class="leg1-month-year flex gap-2">
             <div>
               <label class="block mb-1">Month:</label>
               <select id="month1-0" class="form-control w-28">
@@ -65,6 +66,16 @@
               <select id="year1-0" class="form-control w-28">
                 <!-- Options populated via JavaScript -->
               </select>
+            </div>
+          </div>
+          <div class="leg1-date-range hidden flex gap-2 mt-2">
+            <div>
+              <label class="block mb-1">Start Date:</label>
+              <input type="date" id="startDate1-0" class="form-control w-32" />
+            </div>
+            <div>
+              <label class="block mb-1">End Date:</label>
+              <input type="date" id="endDate1-0" class="form-control w-32" />
             </div>
           </div>
         </div>

--- a/main.js
+++ b/main.js
@@ -219,6 +219,20 @@ if (!opt.disabled) opt.checked = true;
 }
 }
 
+function updateLeg1Fields(index) {
+  const type = document.getElementById(`type1-${index}`)?.value;
+  const monthYear = document.querySelector(`#trade-${index} .leg1-month-year`);
+  const dateRange = document.querySelector(`#trade-${index} .leg1-date-range`);
+  if (!monthYear || !dateRange) return;
+  if (type === 'AVGInter') {
+    monthYear.classList.add('hidden');
+    dateRange.classList.remove('hidden');
+  } else {
+    monthYear.classList.remove('hidden');
+    dateRange.classList.add('hidden');
+  }
+}
+
 async function copyAll() {
   const textarea = document.getElementById('final-output');
   const text = textarea.value.trim();
@@ -269,6 +283,11 @@ div.className = 'trade-block';
   r.addEventListener('change', () => syncLegSides(index));
   });
   syncLegSides(index);
+  const type1 = document.getElementById(`type1-${index}`);
+  if (type1) {
+    type1.addEventListener('change', () => updateLeg1Fields(index));
+    updateLeg1Fields(index);
+  }
 
   renumberTrades();
 }
@@ -286,7 +305,8 @@ if (typeof module !== 'undefined' && module.exports) {
     parseInputDate,
     getSecondBusinessDay,
     getFixPpt,
-    generateRequest
+    generateRequest,
+    updateLeg1Fields
   };
 }
 


### PR DESCRIPTION
## Summary
- allow selecting new AVG Inter price type for Leg 1
- hide or show month/year vs date range inputs when price type changes
- document new behaviour in README
- add unit test for `updateLeg1Fields`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684145815170832e9eb31fc69b111aa4