### PR TITLE
Add Leg 1 date range toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Make sure to visit the full path to `index.html` (not just `/`) because the serv
 Enter quantities as finite positive numbers. Values of zero or negative amounts
 will trigger an error message.
 
+Changing the **Leg&nbsp;1 Price Type** hides the month/year dropdowns and shows a start/end date range when "Fix" is selected.
+
 ## Building
 
 No build step is required. The repository only contains static files (`index.html`, `main.js`, `manifest.json` and `service-worker.js`). If you modify the code you simply refresh the browser to see the changes.

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
               <option value="Fix">Fix</option>
             </select>
           </div>
-          <div class="flex gap-2">
+          <div class="leg1-month-year flex gap-2">
             <div>
               <label class="block mb-1">Month:</label>
               <select id="month1-0" class="form-control w-28">
@@ -65,6 +65,16 @@
               <select id="year1-0" class="form-control w-28">
                 <!-- Options populated via JavaScript -->
               </select>
+            </div>
+          </div>
+          <div class="leg1-date-range hidden flex gap-2 mt-2">
+            <div>
+              <label class="block mb-1">Start:</label>
+              <input type="date" id="start1-0" class="form-control w-32" />
+            </div>
+            <div>
+              <label class="block mb-1">End:</label>
+              <input type="date" id="end1-0" class="form-control w-32" />
             </div>
           </div>
         </div>

--- a/main.js
+++ b/main.js
@@ -219,6 +219,23 @@ if (!opt.disabled) opt.checked = true;
 }
 }
 
+function updateLeg1Fields(index) {
+  const type = document.getElementById(`type1-${index}`);
+  if (!type) return;
+  const trade = document.getElementById(`trade-${index}`);
+  if (!trade) return;
+  const monthYear = trade.querySelector('.leg1-month-year');
+  const range = trade.querySelector('.leg1-date-range');
+  if (!monthYear || !range) return;
+  if (type.value === 'Fix') {
+    monthYear.classList.add('hidden');
+    range.classList.remove('hidden');
+  } else {
+    monthYear.classList.remove('hidden');
+    range.classList.add('hidden');
+  }
+}
+
 async function copyAll() {
   const textarea = document.getElementById('final-output');
   const text = textarea.value.trim();
@@ -269,6 +286,12 @@ div.className = 'trade-block';
   r.addEventListener('change', () => syncLegSides(index));
   });
   syncLegSides(index);
+
+  const typeSel = document.getElementById(`type1-${index}`);
+  if (typeSel) {
+    typeSel.addEventListener('change', () => updateLeg1Fields(index));
+  }
+  updateLeg1Fields(index);
 
   renumberTrades();
 }


### PR DESCRIPTION
## Summary
- wrap month/year and new date range fields for Leg 1
- add `updateLeg1Fields` utility and hook to price type changes
- document the new behaviour in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841856e25ec832eb1a07f8b156542c0