### PR TITLE
Add date range validation

### DIFF
--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -85,6 +85,22 @@ describe('generateRequest', () => {
     const out = document.getElementById('output-0').textContent;
     expect(out).toBe('Please provide a fixing date.');
   });
+
+  test('shows error for invalid date range', () => {
+    const start = document.createElement('input');
+    start.id = 'startDate-0';
+    start.value = '2025-02-01';
+    document.body.appendChild(start);
+    const end = document.createElement('input');
+    end.id = 'endDate-0';
+    end.value = '2025-01-01';
+    document.body.appendChild(end);
+    document.getElementById('qty-0').value = '5';
+    document.getElementById('type2-0').value = 'AVG';
+    generateRequest(0);
+    const out = document.getElementById('output-0').textContent;
+    expect(out).toBe('Start date must be before end date.');
+  });
 });
 
 describe('business day helpers', () => {

--- a/main.js
+++ b/main.js
@@ -127,6 +127,21 @@ const dateFixRaw = fixInput.value;
 const dateFix = dateFixRaw ? formatDate(parseInputDate(dateFixRaw)) : '';
 fixInput.classList.remove('border-red-500');
 const useSamePPT = document.getElementById(`samePpt-${index}`).checked;
+
+const startInput = document.getElementById(`startDate-${index}`);
+const endInput = document.getElementById(`endDate-${index}`);
+const startDateRaw = startInput ? startInput.value : '';
+const endDateRaw = endInput ? endInput.value : '';
+const start = parseInputDate(startDateRaw);
+const end = parseInputDate(endDateRaw);
+if (start && end && start > end) {
+  if (startInput) startInput.classList.add('border-red-500');
+  if (endInput) endInput.classList.add('border-red-500');
+  if (outputEl) outputEl.textContent = 'Start date must be before end date.';
+  return;
+}
+if (startInput) startInput.classList.remove('border-red-500');
+if (endInput) endInput.classList.remove('border-red-500');
 const monthIndex = new Date(`${month} 1, ${year}`).getMonth();
 const pptDateAVG = getSecondBusinessDay(year, monthIndex);
 


### PR DESCRIPTION
## Summary
- check that start date is not after end date when generating a request
- test that invalid date range triggers an error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68418572f28c832eb2da484a7a274be0