### PR TITLE
Support AVGInter handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Make sure to visit the full path to `index.html` (not just `/`) because the serv
 Enter quantities as finite positive numbers. Values of zero or negative amounts
 will trigger an error message.
 
+When Leg 1 uses the `AVGInter` type together with an `AVG` Leg 2, the fixing date input is optional. The PPT for Leg 1 automatically uses the second business day of the month following Leg 2's reference month.
+
 ## Building
 
 No build step is required. The repository only contains static files (`index.html`, `main.js`, `manifest.json` and `service-worker.js`). If you modify the code you simply refresh the browser to see the changes.

--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -13,7 +13,7 @@ function setupDom() {
     <input id="qty-0" />
     <input type="radio" name="side1-0" value="buy" checked>
     <input type="radio" name="side1-0" value="sell">
-    <select id="type1-0"><option value="AVG">AVG</option><option value="Fix">Fix</option></select>
+    <select id="type1-0"><option value="AVG">AVG</option><option value="AVGInter">AVGInter</option><option value="Fix">Fix</option></select>
     <select id="month1-0"><option>January</option><option>February</option></select>
     <select id="year1-0"><option>2025</option></select>
     <input type="radio" name="side2-0" value="buy">
@@ -59,6 +59,16 @@ describe('generateRequest', () => {
     generateRequest(0);
     const out = document.getElementById('output-0').textContent;
     expect(out).toBe('LME Request: Buy 7 mt Al AVG January 2025 Flat and Sell 7 mt Al C2R 02-01-25 ppt 06-01-25 against');
+  });
+
+  test('AVGInter leg1 uses next month PPT when leg2 AVG', () => {
+    document.getElementById('qty-0').value = '5';
+    document.getElementById('type1-0').value = 'AVGInter';
+    document.getElementById('type2-0').value = 'AVG';
+    document.getElementById('fixDate-0').value = '';
+    generateRequest(0);
+    const out = document.getElementById('output-0').textContent;
+    expect(out).toBe('LME Request: Buy 5 mt Al Fix ppt 04-03-25 and Sell 5 mt Al AVG February 2025 Flat against');
   });
 
   test('shows error for non-numeric quantity', () => {

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
             <label class="font-medium">Price Type:</label>
             <select id="type1-0" class="form-control w-32">
               <option value="AVG">AVG</option>
+              <option value="AVGInter">AVGInter</option>
               <option value="Fix">Fix</option>
             </select>
           </div>

--- a/main.js
+++ b/main.js
@@ -122,6 +122,8 @@ const month = document.getElementById(`month1-${index}`).value;
 const year = parseInt(document.getElementById(`year1-${index}`).value);
 const leg2Side = document.querySelector(`input[name='side2-${index}']:checked`).value;
 const leg2Type = document.getElementById(`type2-${index}`).value;
+const month2 = document.getElementById(`month2-${index}`).value;
+const year2 = parseInt(document.getElementById(`year2-${index}`).value);
 const fixInput = document.getElementById(`fixDate-${index}`);
 const dateFixRaw = fixInput.value;
 const dateFix = dateFixRaw ? formatDate(parseInputDate(dateFixRaw)) : '';
@@ -133,14 +135,18 @@ const pptDateAVG = getSecondBusinessDay(year, monthIndex);
 let leg1;
 if (leg1Type === 'AVG') {
   leg1 = `${capitalize(leg1Side)} ${q} mt Al AVG ${month} ${year} Flat`;
+} else if (leg1Type === 'AVGInter' && leg2Type === 'AVG') {
+  const leg2MonthIndex = new Date(`${month2} 1, ${year2}`).getMonth();
+  const nextMonthIndex = (leg2MonthIndex + 1) % 12;
+  const nextYear = year2 + (leg2MonthIndex === 11 ? 1 : 0);
+  const pptFixLeg1 = getSecondBusinessDay(nextYear, nextMonthIndex);
+  leg1 = `${capitalize(leg1Side)} ${q} mt Al Fix ppt ${pptFixLeg1}`;
 } else {
   const pptFixLeg1 = getFixPpt(dateFix);
   leg1 = `${capitalize(leg1Side)} ${q} mt Al Fix ppt ${pptFixLeg1}`;
 }
 let leg2;
 if (leg2Type === 'AVG') {
-const month2 = document.getElementById(`month2-${index}`).value;
-const year2 = parseInt(document.getElementById(`year2-${index}`).value);
 leg2 = `${capitalize(leg2Side)} ${q} mt Al AVG ${month2} ${year2} Flat`;
 } else if (leg2Type === 'Fix') {
   let pptFix;


### PR DESCRIPTION
## Summary
- allow selecting `AVGInter` as a price type
- compute PPT for `AVGInter` leg using second business day of the month after Leg 2 when Leg 2 is `AVG`
- update README with optional fixing date note
- add unit test for the new combination

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684185cd3404832e90c241e0c3766f45