### PR TITLE
Add fix-date toggle logic

### DIFF
--- a/__tests__/fix-date-visibility.test.js
+++ b/__tests__/fix-date-visibility.test.js
@@ -1,0 +1,34 @@
+/** @jest-environment jsdom */
+
+const { updateFixDateVisibility } = require('../main');
+
+describe('updateFixDateVisibility', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="trade-0">
+        <select id="type1-0">
+          <option value="AVGInter">AVGInter</option>
+          <option value="Fix">Fix</option>
+        </select>
+        <select id="type2-0">
+          <option value="AVG">AVG</option>
+          <option value="Fix">Fix</option>
+        </select>
+        <div class="fix-date-container"></div>
+      </div>`;
+  });
+
+  test('hides container when leg1 AVGInter and leg2 AVG', () => {
+    document.getElementById('type1-0').value = 'AVGInter';
+    document.getElementById('type2-0').value = 'AVG';
+    updateFixDateVisibility(0);
+    expect(document.querySelector('.fix-date-container').style.display).toBe('none');
+  });
+
+  test('shows container otherwise', () => {
+    document.getElementById('type1-0').value = 'Fix';
+    document.getElementById('type2-0').value = 'AVG';
+    updateFixDateVisibility(0);
+    expect(document.querySelector('.fix-date-container').style.display).toBe('');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -97,11 +97,13 @@
             </div>
           </div>
           
-          <div class="flex items-center gap-2 mr-2">
-            <span>Fixing Date:</span>
-            <input type="date" id="fixDate-0" class="form-control w-24" />
+          <div class="fix-date-container">
+            <div class="flex items-center gap-2 mr-2">
+              <span>Fixing Date:</span>
+              <input type="date" id="fixDate-0" class="form-control w-24" />
+            </div>
+            <label><input type="checkbox" id="samePpt-0" /> Use AVG PPT Date</label>
           </div>
-          <label><input type="checkbox" id="samePpt-0" /> Use AVG PPT Date</label>
         </div>
       </div>
       <div class="flex flex-wrap items-center gap-2 justify-center">

--- a/main.js
+++ b/main.js
@@ -219,6 +219,16 @@ if (!opt.disabled) opt.checked = true;
 }
 }
 
+function updateFixDateVisibility(index) {
+  const type1 = document.getElementById(`type1-${index}`);
+  const type2 = document.getElementById(`type2-${index}`);
+  const container = document.querySelector(`#trade-${index} .fix-date-container`);
+  if (!type1 || !type2 || !container) return;
+  const hide = type1.value === 'AVGInter' && type2.value === 'AVG';
+  container.style.display = hide ? 'none' : '';
+}
+
+
 async function copyAll() {
   const textarea = document.getElementById('final-output');
   const text = textarea.value.trim();
@@ -268,7 +278,12 @@ div.className = 'trade-block';
   document.querySelectorAll(`input[name='side1-${index}']`).forEach(r => {
   r.addEventListener('change', () => syncLegSides(index));
   });
+  const type1Sel = document.getElementById(`type1-${index}`);
+  const type2Sel = document.getElementById(`type2-${index}`);
+  if (type1Sel) type1Sel.addEventListener('change', () => updateFixDateVisibility(index));
+  if (type2Sel) type2Sel.addEventListener('change', () => updateFixDateVisibility(index));
   syncLegSides(index);
+  updateFixDateVisibility(index);
 
   renumberTrades();
 }
@@ -286,7 +301,8 @@ if (typeof module !== 'undefined' && module.exports) {
     parseInputDate,
     getSecondBusinessDay,
     getFixPpt,
-    generateRequest
+    generateRequest,
+    updateFixDateVisibility
   };
 }
 


### PR DESCRIPTION
## Summary
- wrap fixing date fields in `.fix-date-container`
- hide fix date fields when leg1 uses `AVGInter` and leg2 uses `AVG`
- trigger visibility check when price type changes
- test DOM toggling logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684185cf0e2c832e97d83884abe2c7ca