### PR TITLE
Add leg field toggling logic

### DIFF
--- a/__tests__/toggle-fields.test.js
+++ b/__tests__/toggle-fields.test.js
@@ -1,0 +1,84 @@
+/** @jest-environment jsdom */
+
+const { toggleLeg1Fields, toggleLeg2Fields } = require('../main');
+
+describe('field visibility toggling', () => {
+  let type1, type2,
+    month1, year1, fix1, startDate, endDate,
+    month2, year2, fix2, samePpt;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <select id="type1-0">
+        <option value="AVG">AVG</option>
+        <option value="AVGInter">AVGInter</option>
+        <option value="Fix">Fix</option>
+      </select>
+      <div id="m1"><select id="month1-0"></select></div>
+      <div id="y1"><select id="year1-0"></select></div>
+      <div id="sd"><input id="startDate-0"></div>
+      <div id="ed"><input id="endDate-0"></div>
+      <div id="f1"><input id="fixDate1-0"></div>
+
+      <select id="type2-0">
+        <option value="Fix">Fix</option>
+        <option value="C2R">C2R</option>
+        <option value="AVG">AVG</option>
+      </select>
+      <div id="m2"><select id="month2-0"></select></div>
+      <div id="y2"><select id="year2-0"></select></div>
+      <div id="f2"><input id="fixDate-0"></div>
+      <label id="sppt"><input type="checkbox" id="samePpt-0" /></label>
+    `;
+    type1 = document.getElementById('type1-0');
+    type2 = document.getElementById('type2-0');
+    month1 = document.getElementById('month1-0');
+    year1 = document.getElementById('year1-0');
+    fix1 = document.getElementById('fixDate1-0');
+    startDate = document.getElementById('startDate-0');
+    endDate = document.getElementById('endDate-0');
+    month2 = document.getElementById('month2-0');
+    year2 = document.getElementById('year2-0');
+    fix2 = document.getElementById('fixDate-0');
+    samePpt = document.getElementById('samePpt-0');
+  });
+
+  test('leg1 AVG shows month/year and hides fix/start/end', () => {
+    type1.value = 'AVG';
+    toggleLeg1Fields(0);
+    expect(month1.parentElement.style.display).toBe('');
+    expect(year1.parentElement.style.display).toBe('');
+    expect(fix1.parentElement.style.display).toBe('none');
+    expect(startDate.parentElement.style.display).toBe('none');
+    expect(endDate.parentElement.style.display).toBe('none');
+  });
+
+  test('leg1 Fix shows fix date only', () => {
+    type1.value = 'Fix';
+    toggleLeg1Fields(0);
+    expect(month1.parentElement.style.display).toBe('none');
+    expect(year1.parentElement.style.display).toBe('none');
+    expect(fix1.parentElement.style.display).toBe('');
+  });
+
+  test('leg2 Fix shows fix date and checkbox when leg1 AVG', () => {
+    type1.value = 'AVG';
+    type2.value = 'Fix';
+    toggleLeg1Fields(0);
+    toggleLeg2Fields(0);
+    expect(fix2.parentElement.style.display).toBe('');
+    expect(month2.parentElement.style.display).toBe('none');
+    expect(year2.parentElement.style.display).toBe('none');
+    expect(samePpt.parentElement.style.display).toBe('');
+  });
+
+  test('leg2 AVG hides fix date and checkbox', () => {
+    type2.value = 'AVG';
+    toggleLeg2Fields(0);
+    expect(month2.parentElement.style.display).toBe('');
+    expect(year2.parentElement.style.display).toBe('');
+    expect(fix2.parentElement.style.display).toBe('none');
+    expect(samePpt.parentElement.style.display).toBe('none');
+  });
+});
+

--- a/index.html
+++ b/index.html
@@ -78,6 +78,10 @@
               <input type="date" id="endDate-0" class="form-control w-36" />
             </div>
           </div>
+          <div class="flex items-center gap-2 mr-2 mt-2">
+            <span>Fixing Date:</span>
+            <input type="date" id="fixDate1-0" class="form-control w-24" />
+          </div>
         </div>
         <div>
           <h2 class="font-semibold">Leg 2</h2>

--- a/main.js
+++ b/main.js
@@ -232,10 +232,34 @@ function toggleLeg1Fields(index) {
   const typeSel = document.getElementById(`type1-${index}`);
   const startInput = document.getElementById(`startDate-${index}`);
   const endInput = document.getElementById(`endDate-${index}`);
+  const monthSel = document.getElementById(`month1-${index}`);
+  const yearSel = document.getElementById(`year1-${index}`);
+  const fixInput = document.getElementById(`fixDate1-${index}`);
   if (!typeSel || !startInput || !endInput) return;
-  const show = typeSel.value === 'AVGInter';
-  if (startInput.parentElement) startInput.parentElement.style.display = show ? '' : 'none';
-  if (endInput.parentElement) endInput.parentElement.style.display = show ? '' : 'none';
+  const val = typeSel.value;
+  const showInter = val === 'AVGInter';
+  if (startInput.parentElement) startInput.parentElement.style.display = showInter ? '' : 'none';
+  if (endInput.parentElement) endInput.parentElement.style.display = showInter ? '' : 'none';
+  if (monthSel && monthSel.parentElement) monthSel.parentElement.style.display = val === 'AVG' ? '' : 'none';
+  if (yearSel && yearSel.parentElement) yearSel.parentElement.style.display = val === 'AVG' ? '' : 'none';
+  if (fixInput && fixInput.parentElement) fixInput.parentElement.style.display = (val === 'Fix' || val === 'Spot') ? '' : 'none';
+}
+
+function toggleLeg2Fields(index) {
+  const typeSel = document.getElementById(`type2-${index}`);
+  const monthSel = document.getElementById(`month2-${index}`);
+  const yearSel = document.getElementById(`year2-${index}`);
+  const fixInput = document.getElementById(`fixDate-${index}`);
+  const samePpt = document.getElementById(`samePpt-${index}`);
+  if (!typeSel) return;
+  const val = typeSel.value;
+  if (monthSel && monthSel.parentElement) monthSel.parentElement.style.display = val === 'AVG' ? '' : 'none';
+  if (yearSel && yearSel.parentElement) yearSel.parentElement.style.display = val === 'AVG' ? '' : 'none';
+  if (fixInput && fixInput.parentElement) fixInput.parentElement.style.display = (val === 'Fix' || val === 'C2R') ? '' : 'none';
+  const leg1Type = document.getElementById(`type1-${index}`)?.value;
+  if (samePpt && samePpt.parentElement) {
+    samePpt.parentElement.style.display = leg1Type === 'AVG' && val === 'Fix' ? '' : 'none';
+  }
 }
 
 async function copyAll() {
@@ -284,8 +308,19 @@ div.className = 'trade-block';
   const currentYear = new Date().getFullYear();
   populateYearOptions(`year1-${index}`, currentYear, 3);
   populateYearOptions(`year2-${index}`, currentYear, 3);
-  document.getElementById(`type1-${index}`).addEventListener('change', () => toggleLeg1Fields(index));
+  const type1Sel = document.getElementById(`type1-${index}`);
+  const type2Sel = document.getElementById(`type2-${index}`);
+  if (type1Sel) {
+    type1Sel.addEventListener('change', () => {
+      toggleLeg1Fields(index);
+      toggleLeg2Fields(index);
+    });
+  }
+  if (type2Sel) {
+    type2Sel.addEventListener('change', () => toggleLeg2Fields(index));
+  }
   toggleLeg1Fields(index);
+  toggleLeg2Fields(index);
   document.querySelectorAll(`input[name='side1-${index}']`).forEach(r => {
   r.addEventListener('change', () => syncLegSides(index));
   });
@@ -307,7 +342,9 @@ if (typeof module !== 'undefined' && module.exports) {
     parseInputDate,
     getSecondBusinessDay,
     getFixPpt,
-    generateRequest
+    generateRequest,
+    toggleLeg1Fields,
+    toggleLeg2Fields
   };
 }
 


### PR DESCRIPTION
## Summary
- handle new Fixing Date input for Leg 1 in the template
- show/hide fields via new toggleLeg1Fields and toggleLeg2Fields
- register listeners for both leg type selects
- export toggle helpers
- test leg field visibility behaviour

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68418feb4a50832ebafa58a306db1913