### PR TITLE
Improve leg field toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ day (its PPT date). Leg&nbsp;2's checkbox is visible when Leg&nbsp;1 is set to
 **AVG** and Leg&nbsp;2 is **Fix**. Likewise, Leg&nbsp;1's checkbox appears when
 Leg&nbsp;1 is **Fix** and Leg&nbsp;2 is **AVG**.
 
+Fixing date inputs only appear when a leg uses **Fix** pricing (Leg&nbsp;2 also
+shows it for **C2R**). When one leg is **AVG** and the other **Fix**, checking
+the "Use AVG PPT Date" option automatically fills the fixed leg's date with the
+averaging leg's PPT.
+
 ## Building
 
 No build step is required. The repository only contains static files (`index.html`, `main.js`, `manifest.json` and `service-worker.js`). If you modify the code you simply refresh the browser to see the changes.

--- a/__tests__/toggle-fields.test.js
+++ b/__tests__/toggle-fields.test.js
@@ -1,0 +1,51 @@
+/** @jest-environment jsdom */
+
+const calendarUtils = require('../calendar-utils');
+
+global.calendarUtils = calendarUtils;
+
+document.body.innerHTML = '<select id="calendarType"></select>';
+document.getElementById('calendarType').value = 'gregorian';
+
+const { toggleLeg1Fields, toggleLeg2Fields, getSecondBusinessDay } = require('../main');
+
+beforeEach(() => {
+  document.body.innerHTML = `
+    <select id="calendarType"></select>
+    <select id="type1-0"><option value="AVG">AVG</option><option value="Fix">Fix</option><option value="AVGInter">AVGInter</option></select>
+    <div id="startWrap"><input type="date" id="startDate-0"></div>
+    <div id="endWrap"><input type="date" id="endDate-0"></div>
+    <div id="fix1Wrap"><input type="date" id="fixDate1-0"></div>
+    <select id="type2-0"><option value="Fix">Fix</option><option value="AVG">AVG</option><option value="C2R">C2R</option></select>
+    <div id="fixWrap"><input type="date" id="fixDate-0"></div>
+    <label id="sameWrap"><input type="checkbox" id="samePpt-0"></label>
+    <select id="month1-0"><option>January</option></select>
+    <select id="year1-0"><option>2025</option></select>
+    <select id="month2-0"><option>January</option></select>
+    <select id="year2-0"><option>2025</option></select>
+  `;
+  document.getElementById('calendarType').value = 'gregorian';
+});
+
+test('Leg1 fix fields toggle with price type', () => {
+  document.getElementById('type1-0').value = 'Fix';
+  toggleLeg1Fields(0);
+  expect(document.getElementById('fixDate1-0').parentElement.style.display).toBe('');
+  document.getElementById('type1-0').value = 'AVG';
+  toggleLeg1Fields(0);
+  expect(document.getElementById('fixDate1-0').parentElement.style.display).toBe('none');
+});
+
+test('Leg2 fields toggle and checkbox sets PPT', () => {
+  document.getElementById('type1-0').value = 'AVG';
+  document.getElementById('type2-0').value = 'Fix';
+  const chk = document.getElementById('samePpt-0');
+  chk.checked = true;
+  toggleLeg2Fields(0);
+  expect(document.getElementById('fixDate-0').parentElement.style.display).toBe('');
+  expect(chk.parentElement.style.display).toBe('');
+  const ppt = getSecondBusinessDay(2025,0);
+  const date = calendarUtils.parseDateGregorian(ppt);
+  expect(document.getElementById('fixDate-0').value).toBe(date.toISOString().split('T')[0]);
+});
+

--- a/index.html
+++ b/index.html
@@ -69,16 +69,16 @@
             </div>
           </div>
           <div class="flex gap-2 mt-2">
-            <div>
+            <div style="display:none">
               <label class="block mb-1">Start Date:</label>
               <input type="date" id="startDate-0" class="form-control w-36" />
             </div>
-            <div>
+            <div style="display:none">
               <label class="block mb-1">End Date:</label>
               <input type="date" id="endDate-0" class="form-control w-36" />
             </div>
           </div>
-          <div class="flex items-center gap-2 mr-2 mt-2">
+          <div class="flex items-center gap-2 mr-2 mt-2" style="display:none">
             <span>Fixing Date:</span>
             <input type="date" id="fixDate1-0" class="form-control w-24" />
           </div>

--- a/main.js
+++ b/main.js
@@ -254,11 +254,44 @@ function toggleLeg1Fields(index) {
   const typeSel = document.getElementById(`type1-${index}`);
   const startInput = document.getElementById(`startDate-${index}`);
   const endInput = document.getElementById(`endDate-${index}`);
+  const fixInput = document.getElementById(`fixDate1-${index}`);
   if (!typeSel || !startInput || !endInput) return;
   // Only display the date range inputs for the AVG Inter price type.
   const shouldShowRange = typeSel.value === 'AVGInter';
   if (startInput.parentElement) startInput.parentElement.style.display = shouldShowRange ? '' : 'none';
   if (endInput.parentElement) endInput.parentElement.style.display = shouldShowRange ? '' : 'none';
+  if (fixInput && fixInput.parentElement) {
+    fixInput.parentElement.style.display = typeSel.value === 'Fix' ? '' : 'none';
+  }
+}
+
+function toggleLeg2Fields(index) {
+  const type1 = document.getElementById(`type1-${index}`)?.value;
+  const type2Sel = document.getElementById(`type2-${index}`);
+  const fixInput = document.getElementById(`fixDate-${index}`);
+  const samePpt = document.getElementById(`samePpt-${index}`);
+  if (!type2Sel || !fixInput || !samePpt) return;
+
+  const type2 = type2Sel.value;
+
+  if (fixInput.parentElement) {
+    fixInput.parentElement.style.display = (type2 === 'Fix' || type2 === 'C2R') ? '' : 'none';
+    if (type2 !== 'Fix' && type2 !== 'C2R') fixInput.value = '';
+  }
+
+  const showChk = (type1 === 'AVG' && type2 === 'Fix') || (type1 === 'Fix' && type2 === 'AVG');
+  if (samePpt.parentElement) samePpt.parentElement.style.display = showChk ? '' : 'none';
+  if (!showChk) samePpt.checked = false;
+
+  if (showChk && samePpt.checked) {
+    const avgLeg = type1 === 'AVG' ? 1 : 2;
+    const month = document.getElementById(`month${avgLeg}-${index}`).value;
+    const year = parseInt(document.getElementById(`year${avgLeg}-${index}`).value);
+    const monthIdx = new Date(`${month} 1, ${year}`).getMonth();
+    const pptStr = getSecondBusinessDay(year, monthIdx);
+    const date = parseDate(pptStr);
+    if (fixInput) fixInput.value = date.toISOString().split('T')[0];
+  }
 }
 
 async function copyAll() {
@@ -308,8 +341,14 @@ div.className = 'trade-block';
   const currentYear = new Date().getFullYear();
   populateYearOptions(`year1-${index}`, currentYear, 3);
   populateYearOptions(`year2-${index}`, currentYear, 3);
-  document.getElementById(`type1-${index}`).addEventListener('change', () => toggleLeg1Fields(index));
+  document.getElementById(`type1-${index}`).addEventListener('change', () => {
+    toggleLeg1Fields(index);
+    toggleLeg2Fields(index);
+  });
+  document.getElementById(`type2-${index}`).addEventListener('change', () => toggleLeg2Fields(index));
+  document.getElementById(`samePpt-${index}`).addEventListener('change', () => toggleLeg2Fields(index));
   toggleLeg1Fields(index);
+  toggleLeg2Fields(index);
   document.querySelectorAll(`input[name='side1-${index}']`).forEach(r => {
   r.addEventListener('change', () => syncLegSides(index));
   });
@@ -331,7 +370,9 @@ if (typeof module !== 'undefined' && module.exports) {
     parseInputDate,
     getSecondBusinessDay,
     getFixPpt,
-    generateRequest
+    generateRequest,
+    toggleLeg1Fields,
+    toggleLeg2Fields
   };
 }
 


### PR DESCRIPTION
## Summary
- hide Leg 1 and Leg 2 date inputs based on price types
- automatically update fixing date from AVG PPT when the option is checked
- test new toggleLeg2Fields logic
- document behaviour of new fields

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841a5fab7a8832ebeed6ce2d55e432b