### PR TITLE
Improve trade form price type handling

### DIFF
--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -1,113 +1,124 @@
 /** @jest-environment jsdom */
 
-const calendarUtils = require('../calendar-utils');
+const calendarUtils = require("../calendar-utils");
 global.calendarUtils = calendarUtils;
 
-const { getSecondBusinessDay, getFixPpt, generateRequest } = require('../main');
+const { getSecondBusinessDay, getFixPpt, generateRequest } = require("../main");
 
 document.body.innerHTML = '<select id="calendarType"></select>';
-document.getElementById('calendarType').value = 'gregorian';
+document.getElementById("calendarType").value = "gregorian";
 
 function setupDom() {
   document.body.innerHTML += `
     <input id="qty-0" />
     <input type="radio" name="side1-0" value="buy" checked>
     <input type="radio" name="side1-0" value="sell">
-    <select id="type1-0"><option value="AVG">AVG</option><option value="AVGInter">AVG Inter</option><option value="Fix">Fix</option></select>
+    <select id="type1-0"><option value="">Select</option><option value="AVG">AVG</option><option value="AVGInter">AVG Inter</option><option value="Fix">Fix</option><option value="C2R">C2R</option></select>
     <select id="month1-0"><option>January</option><option>February</option><option>October</option></select>
     <select id="year1-0"><option>2025</option></select>
     <input id="startDate-0" type="date" />
     <input id="endDate-0" type="date" />
+    <input id="startDate2-0" type="date" />
+    <input id="endDate2-0" type="date" />
     <input type="radio" name="side2-0" value="buy">
     <input type="radio" name="side2-0" value="sell" checked>
-    <select id="type2-0"><option value="Fix">Fix</option><option value="C2R">C2R</option><option value="AVG">AVG</option></select>
+    <select id="type2-0"><option value="">Select</option><option value="AVG">AVG</option><option value="AVGInter">AVG Inter</option><option value="Fix">Fix</option><option value="C2R">C2R</option></select>
     <select id="month2-0"><option>February</option><option>October</option></select>
     <select id="year2-0"><option>2025</option></select>
     <input id="fixDate-0" />
-    <input type="checkbox" id="samePpt-0" />
+    <input type="checkbox" id="samePpt1-0" />
+    <input type="checkbox" id="samePpt2-0" />
     <p id="output-0"></p>
     <textarea id="final-output"></textarea>
   `;
 }
 
-describe('generateRequest', () => {
+describe("generateRequest", () => {
   beforeEach(() => {
     document.body.innerHTML = '<select id="calendarType"></select>';
-    document.getElementById('calendarType').value = 'gregorian';
+    document.getElementById("calendarType").value = "gregorian";
     setupDom();
   });
 
-  test('creates AVG request text', () => {
-    document.getElementById('qty-0').value = '10';
-    document.getElementById('type2-0').value = 'AVG';
+  test("creates AVG request text", () => {
+    document.getElementById("qty-0").value = "10";
+    document.getElementById("type2-0").value = "AVG";
     generateRequest(0);
-    const out = document.getElementById('output-0').textContent;
-    expect(out).toBe('LME Request: Buy 10 mt Al AVG January 2025 Flat and Sell 10 mt Al AVG February 2025 Flat against');
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe(
+      "LME Request: Buy 10 mt Al AVG January 2025 Flat and Sell 10 mt Al AVG February 2025 Flat against",
+    );
   });
 
-  test('creates Fix request text', () => {
-    document.getElementById('qty-0').value = '5';
-    document.getElementById('type2-0').value = 'Fix';
-    document.getElementById('fixDate-0').value = '2025-01-02';
+  test("creates Fix request text", () => {
+    document.getElementById("qty-0").value = "5";
+    document.getElementById("type2-0").value = "Fix";
+    document.getElementById("fixDate-0").value = "2025-01-02";
     generateRequest(0);
-    const out = document.getElementById('output-0').textContent;
-    expect(out).toBe('LME Request: Buy 5 mt Al AVG January 2025 Flat and Sell 5 mt Al USD ppt 06-01-25 against');
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe(
+      "LME Request: Buy 5 mt Al AVG January 2025 Flat and Sell 5 mt Al USD ppt 06-01-25 against",
+    );
   });
 
-  test('creates C2R request text', () => {
-    document.getElementById('qty-0').value = '7';
-    document.getElementById('type2-0').value = 'C2R';
-    document.getElementById('fixDate-0').value = '2025-01-02';
+  test("creates C2R request text", () => {
+    document.getElementById("qty-0").value = "7";
+    document.getElementById("type2-0").value = "C2R";
+    document.getElementById("fixDate-0").value = "2025-01-02";
     generateRequest(0);
-    const out = document.getElementById('output-0').textContent;
-    expect(out).toBe('LME Request: Buy 7 mt Al AVG January 2025 Flat and Sell 7 mt Al C2R 02-01-25 ppt 06-01-25 against');
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe(
+      "LME Request: Buy 7 mt Al AVG January 2025 Flat and Sell 7 mt Al C2R 02-01-25 ppt 06-01-25 against",
+    );
   });
 
-  test('creates AVGInter request text', () => {
-    document.getElementById('qty-0').value = '5';
-    document.getElementById('type1-0').value = 'AVGInter';
-    document.getElementById('startDate-0').value = '2025-09-01';
-    document.getElementById('endDate-0').value = '2025-09-10';
-    document.getElementById('type2-0').value = 'AVG';
-    document.getElementById('month2-0').value = 'October';
-    document.getElementById('year2-0').value = '2025';
+  test("creates AVGInter request text", () => {
+    document.getElementById("qty-0").value = "5";
+    document.getElementById("type1-0").value = "AVGInter";
+    document.getElementById("startDate-0").value = "2025-09-01";
+    document.getElementById("endDate-0").value = "2025-09-10";
+    document.getElementById("type2-0").value = "AVG";
+    document.getElementById("month2-0").value = "October";
+    document.getElementById("year2-0").value = "2025";
     generateRequest(0);
-    const out = document.getElementById('output-0').textContent;
-    expect(out).toBe('LME Request: Buy 5 mt Al AVG (01-09-25 \u2013 10-09-25) and Sell 5 mt Al AVG October 2025 Flat against');
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe(
+      "LME Request: Buy 5 mt Al AVG (01-09-25 \u2013 10-09-25) and Sell 5 mt Al AVG October 2025 Flat against",
+    );
   });
 
-  test('shows error for non-numeric quantity', () => {
-    document.getElementById('qty-0').value = 'abc';
-    document.getElementById('type2-0').value = 'AVG';
+  test("shows error for non-numeric quantity", () => {
+    document.getElementById("qty-0").value = "abc";
+    document.getElementById("type2-0").value = "AVG";
     generateRequest(0);
-    const out = document.getElementById('output-0').textContent;
-    expect(out).toBe('Please enter a valid quantity.');
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe("Please enter a valid quantity.");
   });
 
-  test('shows error for negative quantity', () => {
-    document.getElementById('qty-0').value = '-3';
-    document.getElementById('type2-0').value = 'AVG';
+  test("shows error for negative quantity", () => {
+    document.getElementById("qty-0").value = "-3";
+    document.getElementById("type2-0").value = "AVG";
     generateRequest(0);
-    const out = document.getElementById('output-0').textContent;
-    expect(out).toBe('Quantity must be greater than zero.');
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe("Quantity must be greater than zero.");
   });
 
-  test('requires fixing date when needed', () => {
-    document.getElementById('qty-0').value = '5';
-    document.getElementById('type2-0').value = 'C2R';
-    document.getElementById('fixDate-0').value = '';
+  test("requires fixing date when needed", () => {
+    document.getElementById("qty-0").value = "5";
+    document.getElementById("type2-0").value = "C2R";
+    document.getElementById("fixDate-0").value = "";
     generateRequest(0);
-    const out = document.getElementById('output-0').textContent;
-    expect(out).toBe('Please provide a fixing date.');
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe("Please provide a fixing date.");
   });
 });
 
-describe('business day helpers', () => {
-  test('getSecondBusinessDay returns formatted date', () => {
-    expect(getSecondBusinessDay(2025, 0)).toBe('03-01-25');
+describe("business day helpers", () => {
+  test("getSecondBusinessDay returns formatted date", () => {
+    expect(getSecondBusinessDay(2025, 0)).toBe("03-01-25");
   });
 
-  test('getFixPpt computes two business days after fix date', () => {
-    expect(getFixPpt('02-01-25')).toBe('06-01-25');
+  test("getFixPpt computes two business days after fix date", () => {
+    expect(getFixPpt("02-01-25")).toBe("06-01-25");
   });
 });

--- a/__tests__/toggle-fields.test.js
+++ b/__tests__/toggle-fields.test.js
@@ -1,51 +1,65 @@
 /** @jest-environment jsdom */
 
-const calendarUtils = require('../calendar-utils');
+const calendarUtils = require("../calendar-utils");
 
 global.calendarUtils = calendarUtils;
 
 document.body.innerHTML = '<select id="calendarType"></select>';
-document.getElementById('calendarType').value = 'gregorian';
+document.getElementById("calendarType").value = "gregorian";
 
-const { toggleLeg1Fields, toggleLeg2Fields, getSecondBusinessDay } = require('../main');
+const {
+  toggleLeg1Fields,
+  toggleLeg2Fields,
+  getSecondBusinessDay,
+} = require("../main");
 
 beforeEach(() => {
   document.body.innerHTML = `
     <select id="calendarType"></select>
-    <select id="type1-0"><option value="AVG">AVG</option><option value="Fix">Fix</option><option value="AVGInter">AVGInter</option></select>
+    <select id="type1-0"><option value="">Select</option><option value="AVG">AVG</option><option value="Fix">Fix</option><option value="AVGInter">AVGInter</option><option value="C2R">C2R</option></select>
     <div id="startWrap"><input type="date" id="startDate-0"></div>
     <div id="endWrap"><input type="date" id="endDate-0"></div>
     <div id="fix1Wrap"><input type="date" id="fixDate1-0"></div>
-    <select id="type2-0"><option value="Fix">Fix</option><option value="AVG">AVG</option><option value="C2R">C2R</option></select>
+    <label id="sameWrap1"><input type="checkbox" id="samePpt1-0"></label>
+    <select id="type2-0"><option value="">Select</option><option value="AVG">AVG</option><option value="Fix">Fix</option><option value="AVGInter">AVGInter</option><option value="C2R">C2R</option></select>
+    <div id="startWrap2"><input type="date" id="startDate2-0"></div>
+    <div id="endWrap2"><input type="date" id="endDate2-0"></div>
     <div id="fixWrap"><input type="date" id="fixDate-0"></div>
-    <label id="sameWrap"><input type="checkbox" id="samePpt-0"></label>
+    <label id="sameWrap2"><input type="checkbox" id="samePpt2-0"></label>
     <select id="month1-0"><option>January</option></select>
     <select id="year1-0"><option>2025</option></select>
     <select id="month2-0"><option>January</option></select>
     <select id="year2-0"><option>2025</option></select>
   `;
-  document.getElementById('calendarType').value = 'gregorian';
+  document.getElementById("calendarType").value = "gregorian";
 });
 
-test('Leg1 fix fields toggle with price type', () => {
-  document.getElementById('type1-0').value = 'Fix';
+test("Leg1 fix fields toggle with price type", () => {
+  document.getElementById("type1-0").value = "Fix";
   toggleLeg1Fields(0);
-  expect(document.getElementById('fixDate1-0').parentElement.style.display).toBe('');
-  document.getElementById('type1-0').value = 'AVG';
+  expect(
+    document.getElementById("fixDate1-0").parentElement.style.display,
+  ).toBe("");
+  document.getElementById("type1-0").value = "AVG";
   toggleLeg1Fields(0);
-  expect(document.getElementById('fixDate1-0').parentElement.style.display).toBe('none');
+  expect(
+    document.getElementById("fixDate1-0").parentElement.style.display,
+  ).toBe("none");
 });
 
-test('Leg2 fields toggle and checkbox sets PPT', () => {
-  document.getElementById('type1-0').value = 'AVG';
-  document.getElementById('type2-0').value = 'Fix';
-  const chk = document.getElementById('samePpt-0');
+test("Leg2 fields toggle and checkbox sets PPT", () => {
+  document.getElementById("type1-0").value = "AVG";
+  document.getElementById("type2-0").value = "Fix";
+  const chk = document.getElementById("samePpt2-0");
   chk.checked = true;
   toggleLeg2Fields(0);
-  expect(document.getElementById('fixDate-0').parentElement.style.display).toBe('');
-  expect(chk.parentElement.style.display).toBe('');
-  const ppt = getSecondBusinessDay(2025,0);
+  expect(document.getElementById("fixDate-0").parentElement.style.display).toBe(
+    "",
+  );
+  expect(chk.parentElement.style.display).toBe("");
+  const ppt = getSecondBusinessDay(2025, 0);
   const date = calendarUtils.parseDateGregorian(ppt);
-  expect(document.getElementById('fixDate-0').value).toBe(date.toISOString().split('T')[0]);
+  expect(document.getElementById("fixDate-0").value).toBe(
+    date.toISOString().split("T")[0],
+  );
 });
-

--- a/index.html
+++ b/index.html
@@ -1,134 +1,250 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>LME Trade Request Generator</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link href="tailwind.min.css" rel="stylesheet">
-  <link rel="manifest" href="manifest.json">
-  <style>
-    body, input, select, textarea, button {
-      font-family: 'Inter', sans-serif;
-    }
-    .form-control {
-      height: 2.5rem;            /* ensures uniform input height */
-      padding: 0.5rem;
-      border: 1px solid #d1d5db; /* gray-300 */
-      border-radius: 0.25rem;
-    }
-  </style>
-</head>
-<body class="bg-gradient-to-br from-blue-50 to-gray-100 min-h-screen p-6">
-  <div class="max-w-4xl mx-auto space-y-6">
-    <h1 class="text-3xl font-bold mb-6 text-center">LME Trade Request Generator</h1>
-    <div id="trades" class="space-y-6"></div>
-    <div class="space-y-2 bg-white p-6 rounded-lg shadow-md">
-      <textarea id="final-output" class="form-control w-full" style="height: 10rem;" placeholder="All trade requests will appear here..."></textarea>
-      <div id="trade-controls" class="flex flex-wrap items-center gap-2 justify-center pt-2">
-        <button onclick="addTrade()" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded w-32">Add Trade</button>
-        <button onclick="copyAll()" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded w-32">Copy All</button>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LME Trade Request Generator</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link href="tailwind.min.css" rel="stylesheet" />
+    <link rel="manifest" href="manifest.json" />
+    <style>
+      body,
+      input,
+      select,
+      textarea,
+      button {
+        font-family: "Inter", sans-serif;
+      }
+      .form-control {
+        height: 2.5rem; /* ensures uniform input height */
+        padding: 0.5rem;
+        border: 1px solid #d1d5db; /* gray-300 */
+        border-radius: 0.25rem;
+      }
+    </style>
+  </head>
+  <body class="bg-gradient-to-br from-blue-50 to-gray-100 min-h-screen p-6">
+    <div class="max-w-4xl mx-auto space-y-6">
+      <h1 class="text-3xl font-bold mb-6 text-center">
+        LME Trade Request Generator
+      </h1>
+      <div id="trades" class="space-y-6"></div>
+      <div class="space-y-2 bg-white p-6 rounded-lg shadow-md">
+        <textarea
+          id="final-output"
+          class="form-control w-full"
+          style="height: 10rem"
+          placeholder="All trade requests will appear here..."
+        ></textarea>
+        <div
+          id="trade-controls"
+          class="flex flex-wrap items-center gap-2 justify-center pt-2"
+        >
+          <button
+            onclick="addTrade()"
+            class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded w-32"
+          >
+            Add Trade
+          </button>
+          <button
+            onclick="copyAll()"
+            class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded w-32"
+          >
+            Copy All
+          </button>
+        </div>
       </div>
     </div>
-  </div>
 
-  <template id="trade-template">
-    <div class="bg-white p-6 rounded-lg shadow-md space-y-4 mb-6 trade-card">
-      <h2 class="text-xl font-semibold trade-title">Trade 1</h2>
-      <div class="flex items-end gap-3 flex-wrap">
-        <label class="font-semibold">Quantity (mt):</label>
-        <input type="number" id="qty-0" class="form-control w-32" min="0" step="0.01" />
-      </div>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div>
-          <h2 class="font-semibold">Leg 1</h2>
-          <label><input type="radio" name="side1-0" value="buy" checked class="mr-1"/> Buy</label>
-          <label><input type="radio" name="side1-0" value="sell" class="mr-1"/> Sell</label><br />
-          <div class="flex items-center gap-2 mt-2 mb-2">
-            <label class="font-medium">Price Type:</label>
-            <select id="type1-0" class="form-control w-32">
-              <option value="AVG">AVG</option>
-              <option value="AVGInter">AVG Inter</option>
-              <option value="Fix">Fix</option>
-            </select>
-          </div>
-          <div class="flex gap-2">
-            <div>
-              <label class="block mb-1">Month:</label>
-              <select id="month1-0" class="form-control w-28">
-                <option>January</option><option>February</option><option>March</option><option>April</option>
-                <option>May</option><option>June</option><option>July</option><option>August</option>
-                <option>September</option><option>October</option><option>November</option><option>December</option>
+    <template id="trade-template">
+      <div class="bg-white p-6 rounded-lg shadow-md space-y-4 mb-6 trade-card">
+        <h2 class="text-xl font-semibold trade-title">Trade 1</h2>
+        <div class="flex items-end gap-3 flex-wrap">
+          <label class="font-semibold">Quantity (mt):</label>
+          <input
+            type="number"
+            id="qty-0"
+            class="form-control w-32"
+            min="0"
+            step="0.01"
+          />
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <h2 class="font-semibold">Leg 1</h2>
+            <label
+              ><input
+                type="radio"
+                name="side1-0"
+                value="buy"
+                checked
+                class="mr-1"
+              />
+              Buy</label
+            >
+            <label
+              ><input type="radio" name="side1-0" value="sell" class="mr-1" />
+              Sell</label
+            ><br />
+            <div class="flex items-center gap-2 mt-2 mb-2">
+              <label class="font-medium">Price Type:</label>
+              <select id="type1-0" class="form-control w-32">
+                <option value="">Select</option>
+                <option value="AVG">AVG</option>
+                <option value="AVGInter">AVG Inter</option>
+                <option value="Fix">Fix</option>
+                <option value="C2R">C2R</option>
               </select>
             </div>
-            <div>
-              <label class="block mb-1">Year:</label>
-              <select id="year1-0" class="form-control w-28">
-                <!-- Options populated via JavaScript -->
+            <div class="flex gap-2" id="avgFields1-0" style="display: none">
+              <div>
+                <label class="block mb-1">Month:</label>
+                <select id="month1-0" class="form-control w-28">
+                  <option>January</option>
+                  <option>February</option>
+                  <option>March</option>
+                  <option>April</option>
+                  <option>May</option>
+                  <option>June</option>
+                  <option>July</option>
+                  <option>August</option>
+                  <option>September</option>
+                  <option>October</option>
+                  <option>November</option>
+                  <option>December</option>
+                </select>
+              </div>
+              <div>
+                <label class="block mb-1">Year:</label>
+                <select id="year1-0" class="form-control w-28">
+                  <!-- Options populated via JavaScript -->
+                </select>
+              </div>
+            </div>
+            <div class="flex gap-2 mt-2">
+              <div style="display: none">
+                <label class="block mb-1">Start Date:</label>
+                <input type="date" id="startDate-0" class="form-control w-36" />
+              </div>
+              <div style="display: none">
+                <label class="block mb-1">End Date:</label>
+                <input type="date" id="endDate-0" class="form-control w-36" />
+              </div>
+            </div>
+            <div
+              class="flex items-center gap-2 mr-2 mt-2"
+              style="display: none"
+            >
+              <span>Fixing Date:</span>
+              <input type="date" id="fixDate1-0" class="form-control w-24" />
+            </div>
+            <label style="display: none"
+              ><input type="checkbox" id="samePpt1-0" /> Use AVG PPT Date</label
+            >
+          </div>
+          <div>
+            <h2 class="font-semibold">Leg 2</h2>
+            <label
+              ><input
+                type="radio"
+                name="side2-0"
+                value="buy"
+                checked
+                class="mr-1"
+              />
+              Buy</label
+            >
+            <label
+              ><input type="radio" name="side2-0" value="sell" class="mr-1" />
+              Sell</label
+            ><br />
+            <div class="flex items-center gap-2 mt-2 mb-2">
+              <label class="font-medium">Price Type:</label>
+              <select id="type2-0" class="form-control w-32">
+                <option value="">Select</option>
+                <option value="AVG">AVG</option>
+                <option value="AVGInter">AVG Inter</option>
+                <option value="Fix">Fix</option>
+                <option value="C2R">C2R</option>
               </select>
             </div>
-          </div>
-          <div class="flex gap-2 mt-2">
-            <div style="display:none">
-              <label class="block mb-1">Start Date:</label>
-              <input type="date" id="startDate-0" class="form-control w-36" />
+            <div class="flex gap-2" id="avgFields2-0" style="display: none">
+              <div>
+                <label class="block mb-1">Month:</label>
+                <select id="month2-0" class="form-control w-28">
+                  <option>January</option>
+                  <option>February</option>
+                  <option>March</option>
+                  <option>April</option>
+                  <option>May</option>
+                  <option>June</option>
+                  <option>July</option>
+                  <option>August</option>
+                  <option>September</option>
+                  <option>October</option>
+                  <option>November</option>
+                  <option>December</option>
+                </select>
+              </div>
+              <div>
+                <label class="block mb-1">Year:</label>
+                <select id="year2-0" class="form-control w-28">
+                  <!-- Options populated via JavaScript -->
+                </select>
+              </div>
             </div>
-            <div style="display:none">
-              <label class="block mb-1">End Date:</label>
-              <input type="date" id="endDate-0" class="form-control w-36" />
+            <div class="flex gap-2 mt-2">
+              <div style="display: none">
+                <label class="block mb-1">Start Date:</label>
+                <input
+                  type="date"
+                  id="startDate2-0"
+                  class="form-control w-36"
+                />
+              </div>
+              <div style="display: none">
+                <label class="block mb-1">End Date:</label>
+                <input type="date" id="endDate2-0" class="form-control w-36" />
+              </div>
             </div>
-          </div>
-          <div class="flex items-center gap-2 mr-2 mt-2" style="display:none">
-            <span>Fixing Date:</span>
-            <input type="date" id="fixDate1-0" class="form-control w-24" />
+
+            <div class="flex items-center gap-2 mr-2" style="display: none">
+              <span>Fixing Date:</span>
+              <input type="date" id="fixDate-0" class="form-control w-24" />
+            </div>
+            <label style="display: none"
+              ><input type="checkbox" id="samePpt2-0" /> Use AVG PPT Date</label
+            >
           </div>
         </div>
-        <div>
-          <h2 class="font-semibold">Leg 2</h2>
-          <label><input type="radio" name="side2-0" value="buy" checked class="mr-1"/> Buy</label>
-          <label><input type="radio" name="side2-0" value="sell" class="mr-1"/> Sell</label><br />
-          <div class="flex items-center gap-2 mt-2 mb-2">
-            <label class="font-medium">Price Type:</label>
-            <select id="type2-0" class="form-control w-32">
-              <option value="Fix">Fix</option>
-              <option value="C2R">C2R</option>
-              <option value="AVG">AVG</option>
-            </select>
-          </div>
-          <div class="flex gap-2">
-            <div>
-              <label class="block mb-1">Month:</label>
-              <select id="month2-0" class="form-control w-28">
-                <option>January</option><option>February</option><option>March</option><option>April</option>
-                <option>May</option><option>June</option><option>July</option><option>August</option>
-                <option>September</option><option>October</option><option>November</option><option>December</option>
-              </select>
-            </div>
-            <div>
-              <label class="block mb-1">Year:</label>
-              <select id="year2-0" class="form-control w-28">
-                <!-- Options populated via JavaScript -->
-              </select>
-            </div>
-          </div>
-          
-          <div class="flex items-center gap-2 mr-2">
-            <span>Fixing Date:</span>
-            <input type="date" id="fixDate-0" class="form-control w-24" />
-          </div>
-          <label><input type="checkbox" id="samePpt-0" /> Use AVG PPT Date</label>
+        <div class="flex flex-wrap items-center gap-2 justify-center">
+          <button
+            name="generate"
+            class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded w-32"
+          >
+            Generate
+          </button>
+          <button
+            name="clear"
+            class="bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded w-32"
+          >
+            Clear
+          </button>
+          <button
+            name="remove"
+            class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded w-32"
+          >
+            Remove
+          </button>
         </div>
+        <p id="output-0" class="mt-2 font-mono text-sm"></p>
       </div>
-      <div class="flex flex-wrap items-center gap-2 justify-center">
-        <button name="generate" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded w-32">Generate</button>
-        <button name="clear" class="bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded w-32">Clear</button>
-        <button name="remove" class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded w-32">Remove</button>
-      </div>
-      <p id="output-0" class="mt-2 font-mono text-sm"></p>
-    </div>
-  </template>
-  <script src="solarlunar.min.js"></script>
-  <script src="calendar-utils.js"></script>
-  <script src="main.js"></script>
+    </template>
+    <script src="solarlunar.min.js"></script>
+    <script src="calendar-utils.js"></script>
+    <script src="main.js"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,33 +1,35 @@
 let lmeHolidays = {};
 
-if (typeof window === 'undefined' || typeof fetch === 'undefined') {
-  const fs = require('fs');
-  const path = require('path');
+if (typeof window === "undefined" || typeof fetch === "undefined") {
+  const fs = require("fs");
+  const path = require("path");
   try {
-    const file = path.join(__dirname, 'holidays.json');
-    lmeHolidays = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const file = path.join(__dirname, "holidays.json");
+    lmeHolidays = JSON.parse(fs.readFileSync(file, "utf8"));
   } catch (err) {
-    console.error('Failed to read holidays.json:', err);
+    console.error("Failed to read holidays.json:", err);
   }
 } else {
-  fetch('holidays.json')
-    .then(res => res.json())
-    .then(data => { lmeHolidays = data; })
-    .catch(err => console.error('Failed to load holidays.json:', err));
+  fetch("holidays.json")
+    .then((res) => res.json())
+    .then((data) => {
+      lmeHolidays = data;
+    })
+    .catch((err) => console.error("Failed to load holidays.json:", err));
 }
 
 async function loadHolidayData() {
   try {
-    const res = await fetch('https://www.gov.uk/bank-holidays.json');
+    const res = await fetch("https://www.gov.uk/bank-holidays.json");
     const data = await res.json();
-    const events = data['england-and-wales'].events;
-    events.forEach(({date}) => {
+    const events = data["england-and-wales"].events;
+    events.forEach(({ date }) => {
       const year = date.slice(0, 4);
       if (!lmeHolidays[year]) lmeHolidays[year] = [];
       if (!lmeHolidays[year].includes(date)) lmeHolidays[year].push(date);
     });
   } catch (err) {
-    console.error('Failed to load holiday data:', err);
+    console.error("Failed to load holiday data:", err);
   }
 }
 
@@ -35,8 +37,8 @@ async function loadHolidayData() {
 let nextIndex = 0;
 
 function getCalendarType() {
-  const sel = document.getElementById('calendarType');
-  return sel ? sel.value : 'gregorian';
+  const sel = document.getElementById("calendarType");
+  return sel ? sel.value : "gregorian";
 }
 
 function formatDate(date) {
@@ -48,42 +50,44 @@ function parseDate(str) {
 }
 
 function getSecondBusinessDay(year, month) {
-const holidays = lmeHolidays[year] || [];
-let date = new Date(year, month, 1);
-let count = 0;
-while (count < 2) {
-const isoDate = date.toISOString().split('T')[0];
-const day = date.getDay();
-if (day !== 0 && day !== 6 && !holidays.includes(isoDate)) count++;
-if (count < 2) date.setDate(date.getDate() + 1);
-}
-return formatDate(date);
+  const holidays = lmeHolidays[year] || [];
+  let date = new Date(year, month, 1);
+  let count = 0;
+  while (count < 2) {
+    const isoDate = date.toISOString().split("T")[0];
+    const day = date.getDay();
+    if (day !== 0 && day !== 6 && !holidays.includes(isoDate)) count++;
+    if (count < 2) date.setDate(date.getDate() + 1);
+  }
+  return formatDate(date);
 }
 
 function getFixPpt(dateFix) {
-  if (!dateFix) throw new Error('Please provide a fixing date.');
+  if (!dateFix) throw new Error("Please provide a fixing date.");
   const date = parseDate(dateFix);
-  if (!date) throw new Error('Fixing date is invalid.');
+  if (!date) throw new Error("Fixing date is invalid.");
   const holidays = lmeHolidays[date.getFullYear()] || [];
   let count = 0;
   while (count < 2) {
     date.setDate(date.getDate() + 1);
-    const isoDate = date.toISOString().split('T')[0];
+    const isoDate = date.toISOString().split("T")[0];
     const day = date.getDay();
     if (day !== 0 && day !== 6 && !holidays.includes(isoDate)) count++;
   }
   return formatDate(date);
 }
 
-function capitalize(s) { return s.charAt(0).toUpperCase() + s.slice(1); }
+function capitalize(s) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
 
 function populateYearOptions(selectId, start, count) {
   const select = document.getElementById(selectId);
   if (!select) return;
-  select.innerHTML = '';
+  select.innerHTML = "";
   for (let i = 0; i < count; i++) {
     const year = start + i;
-    const opt = document.createElement('option');
+    const opt = document.createElement("option");
     opt.value = year;
     opt.textContent = year;
     select.appendChild(opt);
@@ -92,176 +96,214 @@ function populateYearOptions(selectId, start, count) {
 
 function parseInputDate(value) {
   if (!value) return null;
-  const parts = value.split('-').map(Number);
+  const parts = value.split("-").map(Number);
   if (parts.length !== 3) return null;
   const [y, m, d] = parts;
   return new Date(y, m - 1, d);
 }
 
 function generateRequest(index) {
-const outputEl = document.getElementById(`output-${index}`);
-try {
-const qtyInput = document.getElementById(`qty-${index}`);
-  const q = parseFloat(qtyInput.value);
-  if (!isFinite(q)) {
-    qtyInput.classList.add('border-red-500');
-    if (outputEl) outputEl.textContent = 'Please enter a valid quantity.';
-    qtyInput.focus();
-    return;
-  }
-  if (q <= 0) {
-    qtyInput.classList.add('border-red-500');
-    if (outputEl) outputEl.textContent = 'Quantity must be greater than zero.';
-    qtyInput.focus();
-    return;
-  }
-qtyInput.classList.remove('border-red-500');
-const leg1Side = document.querySelector(`input[name='side1-${index}']:checked`).value;
-const leg1Type = document.getElementById(`type1-${index}`)?.value || 'AVG';
-const month = document.getElementById(`month1-${index}`).value;
-const year = parseInt(document.getElementById(`year1-${index}`).value);
-const startDateRaw = document.getElementById(`startDate-${index}`)?.value || '';
-const endDateRaw = document.getElementById(`endDate-${index}`)?.value || '';
-const leg2Side = document.querySelector(`input[name='side2-${index}']:checked`).value;
-const leg2Type = document.getElementById(`type2-${index}`).value;
-const month2 = document.getElementById(`month2-${index}`).value;
-const year2 = parseInt(document.getElementById(`year2-${index}`).value);
-const fixInputLeg1 = document.getElementById(`fixDate1-${index}`);
-const fixInput = document.getElementById(`fixDate-${index}`);
-const dateFix1Raw = fixInputLeg1 ? fixInputLeg1.value : '';
-const dateFix2Raw = fixInput.value;
-const dateFix1 = dateFix1Raw ? formatDate(parseInputDate(dateFix1Raw)) : '';
-const dateFix2 = dateFix2Raw ? formatDate(parseInputDate(dateFix2Raw)) : '';
-if (fixInputLeg1) fixInputLeg1.classList.remove('border-red-500');
-fixInput.classList.remove('border-red-500');
-const useSamePPT = document.getElementById(`samePpt-${index}`).checked;
-const monthIndex = new Date(`${month2} 1, ${year2}`).getMonth();
-const pptDateAVG = getSecondBusinessDay(year2, monthIndex);
-
-let leg1;
-if (leg1Type === 'AVG') {
-  leg1 = `${capitalize(leg1Side)} ${q} mt Al AVG ${month} ${year} Flat`;
-} else if (leg1Type === 'AVGInter') {
-  const start = parseInputDate(startDateRaw);
-  const end = parseInputDate(endDateRaw);
-  if (!start || !end) throw new Error('Start and end dates are required for AVG Inter.');
-  const startStr = formatDate(start);
-  const endStr = formatDate(end);
-  leg1 = `${capitalize(leg1Side)} ${q} mt Al AVG (${startStr} – ${endStr})`;
-} else {
-  let pptFixLeg1;
+  const outputEl = document.getElementById(`output-${index}`);
   try {
-    pptFixLeg1 = getFixPpt(dateFix1);
-  } catch (err) {
-    err.fixInputId = `fixDate1-${index}`;
-    throw err;
-  }
-  leg1 = `${capitalize(leg1Side)} ${q} mt Al Fix ppt ${pptFixLeg1}`;
-}
-let leg2;
-if (leg2Type === 'AVG') {
-  leg2 = `${capitalize(leg2Side)} ${q} mt Al AVG ${month2} ${year2} Flat`;
-} else if (leg2Type === 'Fix') {
-  let pptFix;
-  if (useSamePPT) {
-    pptFix = pptDateAVG;
-  } else {
-    try {
-      pptFix = getFixPpt(dateFix2);
-    } catch (err) {
-      err.fixInputId = `fixDate-${index}`;
-      throw err;
+    const qtyInput = document.getElementById(`qty-${index}`);
+    const q = parseFloat(qtyInput.value);
+    if (!isFinite(q)) {
+      qtyInput.classList.add("border-red-500");
+      if (outputEl) outputEl.textContent = "Please enter a valid quantity.";
+      qtyInput.focus();
+      return;
     }
-  }
-  leg2 = `${capitalize(leg2Side)} ${q} mt Al USD ppt ${pptFix}`;
-} else if (leg2Type === 'C2R') {
-  let pptFix;
-  try {
-    pptFix = getFixPpt(dateFix2);
-  } catch (err) {
-    err.fixInputId = `fixDate-${index}`;
-    throw err;
-  }
-  leg2 = `${capitalize(leg2Side)} ${q} mt Al C2R ${dateFix2} ppt ${pptFix}`;
-}
+    if (q <= 0) {
+      qtyInput.classList.add("border-red-500");
+      if (outputEl)
+        outputEl.textContent = "Quantity must be greater than zero.";
+      qtyInput.focus();
+      return;
+    }
+    qtyInput.classList.remove("border-red-500");
+    const leg1Side = document.querySelector(
+      `input[name='side1-${index}']:checked`,
+    ).value;
+    const leg1Type = document.getElementById(`type1-${index}`)?.value || "AVG";
+    const month = document.getElementById(`month1-${index}`).value;
+    const year = parseInt(document.getElementById(`year1-${index}`).value);
+    const startDateRaw =
+      document.getElementById(`startDate-${index}`)?.value || "";
+    const endDateRaw = document.getElementById(`endDate-${index}`)?.value || "";
+    const leg2Side = document.querySelector(
+      `input[name='side2-${index}']:checked`,
+    ).value;
+    const leg2Type = document.getElementById(`type2-${index}`).value;
+    const month2 = document.getElementById(`month2-${index}`).value;
+    const year2 = parseInt(document.getElementById(`year2-${index}`).value);
+    const fixInputLeg1 = document.getElementById(`fixDate1-${index}`);
+    const fixInput = document.getElementById(`fixDate-${index}`);
+    const dateFix1Raw = fixInputLeg1 ? fixInputLeg1.value : "";
+    const dateFix2Raw = fixInput.value;
+    const dateFix1 = dateFix1Raw ? formatDate(parseInputDate(dateFix1Raw)) : "";
+    const dateFix2 = dateFix2Raw ? formatDate(parseInputDate(dateFix2Raw)) : "";
+    if (fixInputLeg1) fixInputLeg1.classList.remove("border-red-500");
+    fixInput.classList.remove("border-red-500");
+    const useSamePPT1 = document.getElementById(`samePpt1-${index}`)?.checked;
+    const useSamePPT2 = document.getElementById(`samePpt2-${index}`)?.checked;
+    const monthIndex = new Date(`${month2} 1, ${year2}`).getMonth();
+    const pptDateAVG = getSecondBusinessDay(year2, monthIndex);
 
-  const result = `LME Request: ${leg1} and ${leg2} against`;
-  if (outputEl) outputEl.textContent = result;
-  updateFinalOutput();
-} catch (e) {
-  console.error("Error generating request:", e);
-  if (/Fixing date/.test(e.message)) {
-    const id = e.fixInputId || `fixDate-${index}`;
-    const fixField = document.getElementById(id);
-    if (fixField) {
-      fixField.classList.add('border-red-500');
-      fixField.focus();
+    let leg1;
+    if (leg1Type === "AVG") {
+      leg1 = `${capitalize(leg1Side)} ${q} mt Al AVG ${month} ${year} Flat`;
+    } else if (leg1Type === "AVGInter") {
+      const start = parseInputDate(startDateRaw);
+      const end = parseInputDate(endDateRaw);
+      if (!start || !end)
+        throw new Error("Start and end dates are required for AVG Inter.");
+      const startStr = formatDate(start);
+      const endStr = formatDate(end);
+      leg1 = `${capitalize(leg1Side)} ${q} mt Al AVG (${startStr} – ${endStr})`;
+    } else {
+      let pptFixLeg1;
+      if (useSamePPT1) {
+        pptFixLeg1 = pptDateAVG;
+      } else {
+        try {
+          pptFixLeg1 = getFixPpt(dateFix1);
+        } catch (err) {
+          err.fixInputId = `fixDate1-${index}`;
+          throw err;
+        }
+      }
+      leg1 = `${capitalize(leg1Side)} ${q} mt Al Fix ppt ${pptFixLeg1}`;
     }
+    let leg2;
+    if (leg2Type === "AVG") {
+      leg2 = `${capitalize(leg2Side)} ${q} mt Al AVG ${month2} ${year2} Flat`;
+    } else if (leg2Type === "AVGInter") {
+      const start = parseInputDate(
+        document.getElementById(`startDate2-${index}`)?.value || "",
+      );
+      const end = parseInputDate(
+        document.getElementById(`endDate2-${index}`)?.value || "",
+      );
+      if (!start || !end)
+        throw new Error("Start and end dates are required for AVGInter.");
+      const sStr = formatDate(start);
+      const eStr = formatDate(end);
+      leg2 = `${capitalize(leg2Side)} ${q} mt Al AVG (${sStr} – ${eStr})`;
+    } else if (leg2Type === "Fix") {
+      let pptFix;
+      if (useSamePPT2) {
+        pptFix = pptDateAVG;
+      } else {
+        try {
+          pptFix = getFixPpt(dateFix2);
+        } catch (err) {
+          err.fixInputId = `fixDate-${index}`;
+          throw err;
+        }
+      }
+      leg2 = `${capitalize(leg2Side)} ${q} mt Al USD ppt ${pptFix}`;
+    } else if (leg2Type === "C2R") {
+      let pptFix;
+      try {
+        pptFix = getFixPpt(dateFix2);
+      } catch (err) {
+        err.fixInputId = `fixDate-${index}`;
+        throw err;
+      }
+      leg2 = `${capitalize(leg2Side)} ${q} mt Al C2R ${dateFix2} ppt ${pptFix}`;
+    }
+
+    const result = `LME Request: ${leg1} and ${leg2} against`;
+    if (outputEl) outputEl.textContent = result;
+    updateFinalOutput();
+  } catch (e) {
+    console.error("Error generating request:", e);
+    if (/Fixing date/.test(e.message)) {
+      const id = e.fixInputId || `fixDate-${index}`;
+      const fixField = document.getElementById(id);
+      if (fixField) {
+        fixField.classList.add("border-red-500");
+        fixField.focus();
+      }
+    }
+    if (outputEl) outputEl.textContent = e.message;
   }
-  if (outputEl) outputEl.textContent = e.message;
-}
 }
 
 function clearTrade(index) {
-const inputs = document.querySelectorAll(`#trade-${index} input, #trade-${index} select`);
-inputs.forEach(input => {
-if (input.type === 'radio') input.checked = input.defaultChecked;
-else if (input.type === 'checkbox') input.checked = false;
-else input.value = input.defaultValue;
-});
-document.getElementById(`output-${index}`).textContent = '';
-updateFinalOutput();
-syncLegSides(index);
+  const inputs = document.querySelectorAll(
+    `#trade-${index} input, #trade-${index} select`,
+  );
+  inputs.forEach((input) => {
+    if (input.type === "radio") input.checked = input.defaultChecked;
+    else if (input.type === "checkbox") input.checked = false;
+    else input.value = input.defaultValue;
+  });
+  document.getElementById(`output-${index}`).textContent = "";
+  updateFinalOutput();
+  syncLegSides(index);
 }
 
 function removeTrade(index) {
-const trade = document.getElementById(`trade-${index}`);
-if (trade) {
-trade.remove();
-updateFinalOutput();
- renumberTrades();
-}
+  const trade = document.getElementById(`trade-${index}`);
+  if (trade) {
+    trade.remove();
+    updateFinalOutput();
+    renumberTrades();
+  }
 }
 
 function renumberTrades() {
-  document.querySelectorAll('.trade-title').forEach((el, i) => {
+  document.querySelectorAll(".trade-title").forEach((el, i) => {
     el.textContent = `Trade ${i + 1}`;
   });
 }
 
 function updateFinalOutput() {
-const allOutputs = document.querySelectorAll("[id^='output-']");
-const finalOutput = Array.from(allOutputs).map(el => el.textContent.trim()).filter(t => t).join("\n");
-document.getElementById('final-output').value = finalOutput;
+  const allOutputs = document.querySelectorAll("[id^='output-']");
+  const finalOutput = Array.from(allOutputs)
+    .map((el) => el.textContent.trim())
+    .filter((t) => t)
+    .join("\n");
+  document.getElementById("final-output").value = finalOutput;
 }
 
-function syncLegSides(index) {
-const selected = document.querySelector(`input[name='side1-${index}']:checked`);
-if (!selected) return;
-const leg2Options = document.querySelectorAll(`input[name='side2-${index}']`);
-leg2Options.forEach(opt => {
-opt.disabled = opt.value === selected.value;
-});
-const leg2Checked = document.querySelector(`input[name='side2-${index}']:checked`);
-if (leg2Checked && leg2Checked.disabled) {
-leg2Options.forEach(opt => {
-if (!opt.disabled) opt.checked = true;
-});
-}
+function syncLegSides() {
+  // Sides are independent; no synchronization needed.
 }
 
 function toggleLeg1Fields(index) {
   const typeSel = document.getElementById(`type1-${index}`);
+  const type2 = document.getElementById(`type2-${index}`)?.value;
+  const monthWrap = document.getElementById(`avgFields1-${index}`);
   const startInput = document.getElementById(`startDate-${index}`);
   const endInput = document.getElementById(`endDate-${index}`);
   const fixInput = document.getElementById(`fixDate1-${index}`);
-  if (!typeSel || !startInput || !endInput) return;
-  // Only display the date range inputs for the AVG Inter price type.
-  const shouldShowRange = typeSel.value === 'AVGInter';
-  if (startInput.parentElement) startInput.parentElement.style.display = shouldShowRange ? '' : 'none';
-  if (endInput.parentElement) endInput.parentElement.style.display = shouldShowRange ? '' : 'none';
-  if (fixInput && fixInput.parentElement) {
-    fixInput.parentElement.style.display = typeSel.value === 'Fix' ? '' : 'none';
+  const samePpt = document.getElementById(`samePpt1-${index}`);
+  if (!typeSel) return;
+
+  const val = typeSel.value;
+  if (monthWrap) monthWrap.style.display = val === "AVG" ? "" : "none";
+  if (startInput && startInput.parentElement)
+    startInput.parentElement.style.display = val === "AVGInter" ? "" : "none";
+  if (endInput && endInput.parentElement)
+    endInput.parentElement.style.display = val === "AVGInter" ? "" : "none";
+  if (fixInput && fixInput.parentElement)
+    fixInput.parentElement.style.display =
+      val === "Fix" || val === "C2R" ? "" : "none";
+
+  if (samePpt && samePpt.parentElement) {
+    const showChk = val === "Fix" && type2 === "AVG";
+    samePpt.parentElement.style.display = showChk ? "" : "none";
+    if (!showChk) samePpt.checked = false;
+    if (showChk && samePpt.checked) {
+      const month = document.getElementById(`month2-${index}`).value;
+      const year = parseInt(document.getElementById(`year2-${index}`).value);
+      const monthIdx = new Date(`${month} 1, ${year}`).getMonth();
+      const pptStr = getSecondBusinessDay(year, monthIdx);
+      const date = parseDate(pptStr);
+      if (fixInput) fixInput.value = date.toISOString().split("T")[0];
+    }
   }
 }
 
@@ -269,88 +311,117 @@ function toggleLeg2Fields(index) {
   const type1 = document.getElementById(`type1-${index}`)?.value;
   const type2Sel = document.getElementById(`type2-${index}`);
   const fixInput = document.getElementById(`fixDate-${index}`);
-  const samePpt = document.getElementById(`samePpt-${index}`);
-  if (!type2Sel || !fixInput || !samePpt) return;
+  const samePpt = document.getElementById(`samePpt2-${index}`);
+  const monthWrap = document.getElementById(`avgFields2-${index}`);
+  const startInput = document.getElementById(`startDate2-${index}`);
+  const endInput = document.getElementById(`endDate2-${index}`);
+  if (!type2Sel) return;
 
   const type2 = type2Sel.value;
 
-  if (fixInput.parentElement) {
-    fixInput.parentElement.style.display = (type2 === 'Fix' || type2 === 'C2R') ? '' : 'none';
-    if (type2 !== 'Fix' && type2 !== 'C2R') fixInput.value = '';
+  if (monthWrap) monthWrap.style.display = type2 === "AVG" ? "" : "none";
+  if (startInput && startInput.parentElement)
+    startInput.parentElement.style.display = type2 === "AVGInter" ? "" : "none";
+  if (endInput && endInput.parentElement)
+    endInput.parentElement.style.display = type2 === "AVGInter" ? "" : "none";
+
+  if (fixInput && fixInput.parentElement) {
+    fixInput.parentElement.style.display =
+      type2 === "Fix" || type2 === "C2R" ? "" : "none";
+    if (type2 !== "Fix" && type2 !== "C2R") fixInput.value = "";
   }
 
-  const showChk = (type1 === 'AVG' && type2 === 'Fix') || (type1 === 'Fix' && type2 === 'AVG');
-  if (samePpt.parentElement) samePpt.parentElement.style.display = showChk ? '' : 'none';
-  if (!showChk) samePpt.checked = false;
+  if (samePpt && samePpt.parentElement) {
+    const showChk =
+      (type1 === "AVG" && type2 === "Fix") ||
+      (type1 === "Fix" && type2 === "AVG");
+    samePpt.parentElement.style.display = showChk ? "" : "none";
+    if (!showChk) samePpt.checked = false;
 
-  if (showChk && samePpt.checked) {
-    const avgLeg = type1 === 'AVG' ? 1 : 2;
-    const month = document.getElementById(`month${avgLeg}-${index}`).value;
-    const year = parseInt(document.getElementById(`year${avgLeg}-${index}`).value);
-    const monthIdx = new Date(`${month} 1, ${year}`).getMonth();
-    const pptStr = getSecondBusinessDay(year, monthIdx);
-    const date = parseDate(pptStr);
-    if (fixInput) fixInput.value = date.toISOString().split('T')[0];
+    if (showChk && samePpt.checked) {
+      const avgLeg = type1 === "AVG" ? 1 : 2;
+      const month = document.getElementById(`month${avgLeg}-${index}`).value;
+      const year = parseInt(
+        document.getElementById(`year${avgLeg}-${index}`).value,
+      );
+      const monthIdx = new Date(`${month} 1, ${year}`).getMonth();
+      const pptStr = getSecondBusinessDay(year, monthIdx);
+      const date = parseDate(pptStr);
+      if (fixInput) fixInput.value = date.toISOString().split("T")[0];
+    }
   }
 }
 
 async function copyAll() {
-  const textarea = document.getElementById('final-output');
+  const textarea = document.getElementById("final-output");
   const text = textarea.value.trim();
   if (!text) {
-    alert('Nothing to copy.');
+    alert("Nothing to copy.");
     textarea.focus();
     return;
   }
   try {
     await navigator.clipboard.writeText(text);
-    alert('Copied to clipboard');
+    alert("Copied to clipboard");
   } catch (err) {
-    console.error('Failed to copy text:', err);
-    alert('Failed to copy text');
+    console.error("Failed to copy text:", err);
+    alert("Failed to copy text");
   }
 }
 
 function addTrade() {
   const index = nextIndex++;
-const template = document.getElementById('trade-template');
-const clone = template.content.cloneNode(true);
-// Assign unique IDs (including the new Leg 1 fixing date field)
-clone.querySelectorAll('[id]').forEach(el => {
-  const baseId = el.id.replace(/-\d+$/, '');
-  el.id = `${baseId}-${index}`;
-  if (el.name) el.name = el.name.replace(/-\d+$/, `-${index}`);
-});
-clone.querySelectorAll('[name]:not([id])').forEach(el => {
-el.name = el.name.replace(/-\d+$/, `-${index}`);
-});
-clone.querySelector("[id^='output-']").id = `output-${index}`;
- const title = clone.querySelector('.trade-title');
- if (title) title.textContent = `Trade ${index + 1}`;
-  clone.querySelector("button[name='generate']").setAttribute('onclick', `generateRequest(${index})`);
-  clone.querySelector("button[name='clear']").setAttribute('onclick', `clearTrade(${index})`);
-  clone.querySelector("button[name='remove']").setAttribute('onclick', `removeTrade(${index})`);
-const div = document.createElement('div');
-div.id = `trade-${index}`;
-div.className = 'trade-block';
+  const template = document.getElementById("trade-template");
+  const clone = template.content.cloneNode(true);
+  // Assign unique IDs (including the new Leg 1 fixing date field)
+  clone.querySelectorAll("[id]").forEach((el) => {
+    const baseId = el.id.replace(/-\d+$/, "");
+    el.id = `${baseId}-${index}`;
+    if (el.name) el.name = el.name.replace(/-\d+$/, `-${index}`);
+  });
+  clone.querySelectorAll("[name]:not([id])").forEach((el) => {
+    el.name = el.name.replace(/-\d+$/, `-${index}`);
+  });
+  clone.querySelector("[id^='output-']").id = `output-${index}`;
+  const title = clone.querySelector(".trade-title");
+  if (title) title.textContent = `Trade ${index + 1}`;
+  clone
+    .querySelector("button[name='generate']")
+    .setAttribute("onclick", `generateRequest(${index})`);
+  clone
+    .querySelector("button[name='clear']")
+    .setAttribute("onclick", `clearTrade(${index})`);
+  clone
+    .querySelector("button[name='remove']")
+    .setAttribute("onclick", `removeTrade(${index})`);
+  const div = document.createElement("div");
+  div.id = `trade-${index}`;
+  div.className = "trade-block";
   div.appendChild(clone);
-  const trades = document.getElementById('trades');
+  const trades = document.getElementById("trades");
   if (trades) {
     trades.appendChild(div);
   }
   const currentYear = new Date().getFullYear();
   populateYearOptions(`year1-${index}`, currentYear, 3);
   populateYearOptions(`year2-${index}`, currentYear, 3);
-  document.getElementById(`type1-${index}`).addEventListener('change', () => {
+  document.getElementById(`type1-${index}`).addEventListener("change", () => {
     toggleLeg1Fields(index);
     toggleLeg2Fields(index);
   });
-  document.getElementById(`type2-${index}`).addEventListener('change', () => toggleLeg2Fields(index));
-  document.getElementById(`samePpt-${index}`).addEventListener('change', () => toggleLeg2Fields(index));
+  document
+    .getElementById(`type2-${index}`)
+    .addEventListener("change", () => toggleLeg2Fields(index));
+  document
+    .getElementById(`samePpt1-${index}`)
+    .addEventListener("change", () => toggleLeg1Fields(index));
+  document
+    .getElementById(`samePpt2-${index}`)
+    .addEventListener("change", () => toggleLeg2Fields(index));
   toggleLeg1Fields(index);
   toggleLeg2Fields(index);
-  document.querySelectorAll(`input[name='side1-${index}']`).forEach(r => {
-  r.addEventListener('change', () => syncLegSides(index));
+  document.querySelectorAll(`input[name='side1-${index}']`).forEach((r) => {
+    r.addEventListener("change", () => syncLegSides(index));
   });
   syncLegSides(index);
 
@@ -360,19 +431,19 @@ div.className = 'trade-block';
 window.onload = () => {
   loadHolidayData().finally(() => addTrade());
 };
-if ('serviceWorker' in navigator) {
-navigator.serviceWorker.register("service-worker.js")
-.catch(err => console.error("Service Worker registration failed:", err));
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker
+    .register("service-worker.js")
+    .catch((err) => console.error("Service Worker registration failed:", err));
 }
 
-if (typeof module !== 'undefined' && module.exports) {
+if (typeof module !== "undefined" && module.exports) {
   module.exports = {
     parseInputDate,
     getSecondBusinessDay,
     getFixPpt,
     generateRequest,
     toggleLeg1Fields,
-    toggleLeg2Fields
+    toggleLeg2Fields,
   };
 }
-


### PR DESCRIPTION
## Summary
- allow price types to be chosen independently for each leg
- add "Select" placeholder and C2R option to both price type dropdowns
- hide and reveal inputs based on the chosen price type
- add AVG PPT checkbox for whichever leg is fixed
- extend Leg 2 with averaging period fields
- update tests for new inputs and behaviour

## Testing
- `npx prettier --write index.html main.js __tests__/toggle-fields.test.js __tests__/generate-request.test.js`
- `npx eslint .` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b1b6a02c832ea01dca6fe9c0d770