### PR TITLE
Enhance PPT handling and enforce leg sides

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ day (its PPT date). Leg&nbsp;2's checkbox is visible when Leg&nbsp;1 is set to
 **AVG** and Leg&nbsp;2 is **Fix**. Likewise, Leg&nbsp;1's checkbox appears when
 Leg&nbsp;1 is **Fix** and Leg&nbsp;2 is **AVG**.
 
+Only the leg priced as **Fix** shows this checkbox. When checked the generated
+request omits the PPT from the fixed leg and displays it only on the averaging
+leg. If you enter a specific fixing date instead, the request shows PPT dates
+for both legs (two business days after the fixing date for the fixed leg and the
+averaging leg's second business day of the following month).
+
+The Buy/Sell options of the two legs are synchronised: selecting **Buy** on Leg
+1 automatically selects **Sell** on Leg 2 and vice versa.
+
 Fixing date inputs only appear when a leg uses **Fix** pricing (Leg&nbsp;2 also
 shows it for **C2R**). When one leg is **AVG** and the other **Fix**, checking
 the "Use AVG PPT Date" option automatically fills the fixed leg's date with the

--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -57,7 +57,21 @@ describe("generateRequest", () => {
     generateRequest(0);
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe(
-      "LME Request: Buy 5 mt Al AVG January 2025 Flat and Sell 5 mt Al USD ppt 06-01-25 against",
+      "LME Request: Buy 5 mt Al AVG January 2025 ppt 04-02-25 Flat and Sell 5 mt Al USD ppt 06-01-25 against",
+    );
+  });
+
+  test("uses AVG PPT date and hides Fix PPT", () => {
+    document.getElementById("qty-0").value = "8";
+    document.getElementById("type1-0").value = "Fix";
+    document.getElementById("type2-0").value = "AVG";
+    document.getElementById("samePpt1-0").checked = true;
+    document.getElementById("month2-0").value = "February";
+    document.getElementById("year2-0").value = "2025";
+    generateRequest(0);
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe(
+      "LME Request: Buy 8 mt Al Fix and Sell 8 mt Al AVG February 2025 ppt 04-03-25 Flat against",
     );
   });
 
@@ -115,7 +129,7 @@ describe("generateRequest", () => {
 
 describe("business day helpers", () => {
   test("getSecondBusinessDay returns formatted date", () => {
-    expect(getSecondBusinessDay(2025, 0)).toBe("03-01-25");
+    expect(getSecondBusinessDay(2025, 0)).toBe("04-02-25");
   });
 
   test("getFixPpt computes two business days after fix date", () => {

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -23,7 +23,7 @@ describe('parseInputDate', () => {
 describe('business day helpers', () => {
   test('getSecondBusinessDay returns formatted date', () => {
     const res = getSecondBusinessDay(2025, 0);
-    expect(res).toBe('03-01-25');
+    expect(res).toBe('04-02-25');
   });
 
   test('getFixPpt computes two business days after fix date', () => {

--- a/__tests__/toggle-fields.test.js
+++ b/__tests__/toggle-fields.test.js
@@ -52,11 +52,15 @@ test("Leg2 fields toggle and checkbox sets PPT", () => {
   document.getElementById("type2-0").value = "Fix";
   const chk = document.getElementById("samePpt2-0");
   chk.checked = true;
+  toggleLeg1Fields(0);
   toggleLeg2Fields(0);
   expect(document.getElementById("fixDate-0").parentElement.style.display).toBe(
     "",
   );
   expect(chk.parentElement.style.display).toBe("");
+  expect(document.getElementById("samePpt1-0").parentElement.style.display).toBe(
+    "none",
+  );
   const ppt = getSecondBusinessDay(2025, 0);
   const date = calendarUtils.parseDateGregorian(ppt);
   expect(document.getElementById("fixDate-0").value).toBe(


### PR DESCRIPTION
## Summary
- calculate AVG leg PPT using next month's second business day
- restrict `Use AVG PPT Date` to the fixed leg and update leg text
- add side synchronization so legs cannot share the same side
- update README with new behaviour
- adjust tests for PPT calculation and new features

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841b6a21da8832ea436d3ac7a2552a8