### PR TITLE
Update date format and AVG Inter text

### DIFF
--- a/__tests__/calendar-utils.test.js
+++ b/__tests__/calendar-utils.test.js
@@ -16,7 +16,7 @@ describe('Gregorian utilities', () => {
   test('formatDateGregorian and parseDateGregorian round trip', () => {
     const date = new Date(2023, 0, 5);
     const str = formatDateGregorian(date);
-    expect(str).toBe('05-01-23');
+    expect(str).toBe('05/01/23');
     const parsed = parseDateGregorian(str);
     expect(parsed).toEqual(date);
   });
@@ -29,11 +29,11 @@ describe('Gregorian utilities', () => {
 describe('Chinese utilities', () => {
   test('formatDateChinese uses solarlunar', () => {
     const date = new Date(2023, 4, 15);
-    expect(formatDateChinese(date)).toBe('15-05-23');
+    expect(formatDateChinese(date)).toBe('15/05/23');
   });
 
   test('parseDateChinese uses solarlunar', () => {
-    const date = parseDateChinese('05-03-23');
+    const date = parseDateChinese('05/03/23');
     expect(date).toEqual(new Date(2023, 2, 5));
   });
 });

--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -57,7 +57,7 @@ describe("generateRequest", () => {
     generateRequest(0);
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe(
-      "LME Request: Buy 5 mt Al AVG January 2025 Flat and Sell 5 mt Al USD ppt 06-01-25 against",
+      "LME Request: Buy 5 mt Al AVG January 2025 Flat and Sell 5 mt Al USD ppt 06/01/25 against",
     );
   });
 
@@ -68,7 +68,7 @@ describe("generateRequest", () => {
     generateRequest(0);
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe(
-      "LME Request: Buy 7 mt Al AVG January 2025 Flat and Sell 7 mt Al C2R 02-01-25 ppt 06-01-25 against",
+      "LME Request: Buy 7 mt Al AVG January 2025 Flat and Sell 7 mt Al C2R 02/01/25 ppt 06/01/25 against",
     );
   });
 
@@ -83,7 +83,7 @@ describe("generateRequest", () => {
     generateRequest(0);
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe(
-      "LME Request: Buy 5 mt Al AVG (01-09-25 \u2013 10-09-25) and Sell 5 mt Al AVG October 2025 Flat against",
+      "LME Request: Buy 5 mt Al Fixing AVG 01/09/25 to 10/09/25 and Sell 5 mt Al AVG October 2025 Flat against",
     );
   });
 
@@ -115,10 +115,10 @@ describe("generateRequest", () => {
 
 describe("business day helpers", () => {
   test("getSecondBusinessDay returns formatted date", () => {
-    expect(getSecondBusinessDay(2025, 0)).toBe("03-01-25");
+    expect(getSecondBusinessDay(2025, 0)).toBe("03/01/25");
   });
 
   test("getFixPpt computes two business days after fix date", () => {
-    expect(getFixPpt("02-01-25")).toBe("06-01-25");
+    expect(getFixPpt("02/01/25")).toBe("06/01/25");
   });
 });

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -23,11 +23,11 @@ describe('parseInputDate', () => {
 describe('business day helpers', () => {
   test('getSecondBusinessDay returns formatted date', () => {
     const res = getSecondBusinessDay(2025, 0);
-    expect(res).toBe('03-01-25');
+    expect(res).toBe('03/01/25');
   });
 
   test('getFixPpt computes two business days after fix date', () => {
-    const res = getFixPpt('02-01-25');
-    expect(res).toBe('06-01-25');
+    const res = getFixPpt('02/01/25');
+    expect(res).toBe('06/01/25');
   });
 });

--- a/calendar-utils.js
+++ b/calendar-utils.js
@@ -6,12 +6,12 @@
     const d = String(date.getDate()).padStart(2,'0');
     const m = String(date.getMonth()+1).padStart(2,'0');
     const y = String(date.getFullYear()).slice(-2);
-    return `${d}-${m}-${y}`;
+    return `${d}/${m}/${y}`;
   }
 
   function parseDateGregorian(str){
     if (typeof str !== 'string') return null;
-    const match = str.trim().match(/^(\d{2})-(\d{2})-(\d{2})$/);
+    const match = str.trim().match(/^(\d{2})\/(\d{2})\/(\d{2})$/);
     if (!match) return null;
     const day = parseInt(match[1],10);
     const month = parseInt(match[2],10)-1;
@@ -29,12 +29,12 @@
     const d = String(lunar.lDay).padStart(2,'0');
     const m = String(lunar.lMonth).padStart(2,'0');
     const y = String(lunar.lYear).slice(-2);
-    return `${d}-${m}-${y}`;
+    return `${d}/${m}/${y}`;
   }
 
   function parseDateChinese(str){
     if (!solar || typeof str !== 'string') return null;
-    const match = str.trim().match(/^(\d{2})-(\d{2})-(\d{2})$/);
+    const match = str.trim().match(/^(\d{2})\/(\d{2})\/(\d{2})$/);
     if (!match) return null;
     const day = parseInt(match[1],10);
     const month = parseInt(match[2],10);

--- a/main.js
+++ b/main.js
@@ -159,7 +159,7 @@ function generateRequest(index) {
         throw new Error("Start and end dates are required for AVG Inter.");
       const startStr = formatDate(start);
       const endStr = formatDate(end);
-      leg1 = `${capitalize(leg1Side)} ${q} mt Al AVG (${startStr} – ${endStr})`;
+      leg1 = `${capitalize(leg1Side)} ${q} mt Al Fixing AVG ${startStr} to ${endStr}`;
     } else {
       let pptFixLeg1;
       if (useSamePPT1) {
@@ -188,7 +188,7 @@ function generateRequest(index) {
         throw new Error("Start and end dates are required for AVGInter.");
       const sStr = formatDate(start);
       const eStr = formatDate(end);
-      leg2 = `${capitalize(leg2Side)} ${q} mt Al AVG (${sStr} – ${eStr})`;
+      leg2 = `${capitalize(leg2Side)} ${q} mt Al Fixing AVG ${sStr} to ${eStr}`;
     } else if (leg2Type === "Fix") {
       let pptFix;
       if (useSamePPT2) {


### PR DESCRIPTION
## Summary
- format output dates with `/` instead of `-`
- change AVGInter text to use `Fixing AVG <start> to <end>`
- update tests for new date format

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bf7c9bc0832eb07f0d321b1b8875