### PR TITLE
Add holidays.json to cached files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ No build step is required. The repository only contains static files (`index.htm
 
 ## Service worker
 
-`service-worker.js` caches the essential files (`index.html`, `main.js`, `calendar-utils.js`, `solarlunar.min.js`, `tailwind.min.css` and the service worker itself) when the app is installed. This lets the app continue working offline after the first visit.
+`service-worker.js` caches the essential files (`index.html`, `main.js`, `calendar-utils.js`, `holidays.json`, `solarlunar.min.js`, `tailwind.min.css` and the service worker itself) when the app is installed. This lets the app continue working offline after the first visit.
+
+`holidays.json` was added in cache version 6 so holiday data is available offline.
 
 The worker uses a `CACHE_VERSION` constant to build a cache name (`lme-cache-v<version>`). Increment this value during a release so clients fetch the updated files. The activation step deletes any caches that don't match this name. During installation it also verifies that all core files were cached successfully.
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,11 +1,12 @@
 // Update this version when releasing a new build so clients refresh cached files
-const CACHE_VERSION = 5;
+const CACHE_VERSION = 6;
 const CACHE_NAME = `lme-cache-v${CACHE_VERSION}`;
 
 const FILES_TO_CACHE = [
   'index.html',
   'main.js',
   'calendar-utils.js',
+  'holidays.json',
   'solarlunar.min.js',
   'tailwind.min.css',
   'manifest.json',


### PR DESCRIPTION
## Summary
- cache `holidays.json` so holiday data is available offline
- bump `CACHE_VERSION` to clear old caches
- document the change in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841c5d965b4832e9029cee05746144e