### PR TITLE
Add update-holidays npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,11 @@ latest data from the [GOV.UK Bank Holidays API](https://www.gov.uk/bank-holidays
 Run the following command whenever you want to refresh `holidays.json`:
 
 ```bash
-node scripts/update-holidays.js
+npm run update-holidays
 ```
+
+This command downloads the latest dates from the GOV.UK service, so make sure
+you are connected to the internet when running it.
 
 ## Prerequisites
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "jest",
     "start": "http-server -p 8000",
     "lint": "eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "update-holidays": "node scripts/update-holidays.js"
   },
   "devDependencies": {
     "eslint": "^8.57.1",


### PR DESCRIPTION
## Summary
- add `update-holidays` npm script
- document `npm run update-holidays` usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841c92fd8dc832eb092ef717822f1a6