### PR TITLE
Add Node.js >=18 engine requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ node scripts/update-holidays.js
 
 - A modern browser that supports service workers.
 - Any local HTTP server (Python 3, Node.js, etc.) if you want to run it locally.
+- Node.js 18 or later.
 
 ## Running tests
 

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0-beta.3",
     "prettier": "^3.5.3"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
## Summary
- enforce Node.js >=18 in package.json
- document Node.js version in prerequisites

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841c930fd80832e9b04495a1dd6df90