### PR TITLE
Implement date validation

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -7,7 +7,13 @@ global.calendarUtils = calendarUtils;
 document.body.innerHTML = '<select id="calendarType"></select>';
 document.getElementById('calendarType').value = 'gregorian';
 
-const { parseInputDate, getSecondBusinessDay, getFixPpt } = require('../main');
+const {
+  parseInputDate,
+  getSecondBusinessDay,
+  getFixPpt,
+  updateEndDateMin,
+  updateAvgRestrictions,
+} = require('../main');
 
 describe('parseInputDate', () => {
   test('parses yyyy-mm-dd string', () => {
@@ -29,5 +35,34 @@ describe('business day helpers', () => {
   test('getFixPpt computes two business days after fix date', () => {
     const res = getFixPpt('02/01/25');
     expect(res).toBe('06/01/25');
+  });
+});
+
+describe('date restrictions', () => {
+  test('updateEndDateMin sets min correctly', () => {
+    document.body.innerHTML +=
+      '<input type="date" id="startDate-0"><input type="date" id="endDate-0">';
+    const start = document.getElementById('startDate-0');
+    const end = document.getElementById('endDate-0');
+    start.value = '2025-05-10';
+    updateEndDateMin(0, 1);
+    expect(end.min).toBe('2025-05-11');
+  });
+
+  test('updateAvgRestrictions disables earlier months', () => {
+    document.body.innerHTML += `
+      <select id="type1-0"><option value="">Select</option><option value="AVG">AVG</option><option value="AVGInter">AVGInter</option></select>
+      <select id="type2-0"><option value="">Select</option><option value="AVG">AVG</option><option value="AVGInter">AVGInter</option></select>
+      <input type="date" id="endDate2-0">
+      <select id="month1-0"><option>January</option><option>February</option><option>March</option></select>
+      <select id="year1-0"><option>2025</option><option>2026</option></select>
+    `;
+    document.getElementById('type1-0').value = 'AVG';
+    document.getElementById('type2-0').value = 'AVGInter';
+    document.getElementById('endDate2-0').value = '2025-02-15';
+    updateAvgRestrictions(0);
+    const opts = document.getElementById('month1-0').options;
+    expect(opts[0].disabled).toBe(true);
+    expect(opts[1].disabled).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- enforce minimum date selection across all calendar fields
- block end date before start date
- restrict AVG month/year when paired with AVG Inter
- test date helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841eb4ae5c0832e95dff697cad06e8f