### PR TITLE
Fix AVG PPT use on Fix legs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ day (its PPT date). Leg&nbsp;2's checkbox is visible when Leg&nbsp;1 is set to
 Leg&nbsp;1 is **Fix** and Leg&nbsp;2 is **AVG**.
 
 Only the leg priced as **Fix** shows this checkbox. When checked the generated
-request omits the PPT from the fixed leg and displays it only on the averaging
-leg. If you enter a specific fixing date instead, the request shows PPT dates
-for both legs (two business days after the fixing date for the fixed leg and the
-averaging leg's second business day of the following month).
+request uses the averaging leg's PPT for that fixed leg and displays the date
+only on the fixed side. If you enter a specific fixing date instead, the request
+shows PPT dates for both legs (two business days after the fixing date for the
+fixed leg and the averaging leg's second business day of the following month).
 
 The Buy/Sell options of the two legs are synchronised: selecting **Buy** on Leg
 1 automatically selects **Sell** on Leg 2 and vice versa.

--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -61,7 +61,7 @@ describe("generateRequest", () => {
     );
   });
 
-  test("uses AVG PPT date and hides Fix PPT", () => {
+  test("uses AVG PPT date on Fix leg", () => {
     document.getElementById("qty-0").value = "8";
     document.getElementById("type1-0").value = "Fix";
     document.getElementById("type2-0").value = "AVG";
@@ -71,7 +71,21 @@ describe("generateRequest", () => {
     generateRequest(0);
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe(
-      "LME Request: Buy 8 mt Al Fix and Sell 8 mt Al AVG February 2025 ppt 04/03/25 Flat against",
+      "LME Request: Buy 8 mt Al USD ppt 04/03/25 and Sell 8 mt Al AVG February 2025 Flat against",
+    );
+  });
+
+  test("uses AVG PPT date on second Fix leg", () => {
+    document.getElementById("qty-0").value = "12";
+    document.getElementById("type1-0").value = "AVG";
+    document.getElementById("type2-0").value = "Fix";
+    document.getElementById("samePpt2-0").checked = true;
+    document.getElementById("month1-0").value = "October";
+    document.getElementById("year1-0").value = "2025";
+    generateRequest(0);
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe(
+      "LME Request: Buy 12 mt Al AVG October 2025 Flat and Sell 12 mt Al USD ppt 04/11/25 against",
     );
   });
 

--- a/main.js
+++ b/main.js
@@ -260,8 +260,8 @@ function generateRequest(index) {
 
     let leg1;
     const showPptAvg =
-      (leg2Type === "Fix" && (useSamePPT2 || dateFix2Raw)) ||
-      (leg1Type === "Fix" && (useSamePPT1 || dateFix1Raw));
+      (leg2Type === "Fix" && dateFix2Raw) ||
+      (leg1Type === "Fix" && dateFix1Raw);
     if (leg1Type === "AVG") {
       leg1 = `${capitalize(leg1Side)} ${q} mt Al AVG ${month} ${year}`;
       if (showPptAvg) leg1 += ` ppt ${pptDateAVG}`;
@@ -278,7 +278,7 @@ function generateRequest(index) {
     } else {
       let pptFixLeg1;
       if (useSamePPT1) {
-        leg1 = `${capitalize(leg1Side)} ${q} mt Al Fix`;
+        leg1 = `${capitalize(leg1Side)} ${q} mt Al USD ppt ${pptDateAVG}`;
       } else {
         try {
           pptFixLeg1 = getFixPpt(dateFix1);
@@ -286,7 +286,7 @@ function generateRequest(index) {
           err.fixInputId = `fixDate1-${index}`;
           throw err;
         }
-        leg1 = `${capitalize(leg1Side)} ${q} mt Al Fix ppt ${pptFixLeg1}`;
+        leg1 = `${capitalize(leg1Side)} ${q} mt Al USD ppt ${pptFixLeg1}`;
       }
     }
     let leg2;
@@ -310,7 +310,7 @@ function generateRequest(index) {
     } else if (leg2Type === "Fix") {
       let pptFix;
       if (useSamePPT2) {
-        leg2 = `${capitalize(leg2Side)} ${q} mt Al Fix`;
+        leg2 = `${capitalize(leg2Side)} ${q} mt Al USD ppt ${pptDateAVG}`;
       } else {
         try {
           pptFix = getFixPpt(dateFix2);

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 // Update this version when releasing a new build so clients refresh cached files
-const CACHE_VERSION = 7;
+const CACHE_VERSION = 8;
 const CACHE_NAME = `lme-cache-v${CACHE_VERSION}`;
 
 const FILES_TO_CACHE = [


### PR DESCRIPTION
## Summary
- show AVG PPT on the fixed leg when 'Use AVG PPT Date' is enabled
- document new behavior in README
- update tests for the new request formatting
- bump service worker cache version

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684203e49008832ead4f3012cac8a46f