### PR TITLE
Fix showPptAvg logic

### DIFF
--- a/main.js
+++ b/main.js
@@ -260,8 +260,10 @@ function generateRequest(index) {
 
     let leg1;
     const showPptAvg =
-      (leg2Type === "Fix" && dateFix2Raw) ||
-      (leg1Type === "Fix" && dateFix1Raw);
+      !useSamePPT1 &&
+      !useSamePPT2 &&
+      ((leg2Type === "Fix" && dateFix2Raw) ||
+        (leg1Type === "Fix" && dateFix1Raw));
     if (leg1Type === "AVG") {
       leg1 = `${capitalize(leg1Side)} ${q} mt Al AVG ${month} ${year}`;
       if (showPptAvg) leg1 += ` ppt ${pptDateAVG}`;


### PR DESCRIPTION
## Summary
- ensure the PPT average text only appears when neither leg uses the AVG PPT date

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684208f8b110832e8eebb25495651d8c