### PR TITLE
Add placeholders to trade template inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@
             class="form-control w-32"
             min="0"
             step="0.01"
+            placeholder="Ex.: 100"
           />
         </div>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -128,11 +129,21 @@
             <div class="flex gap-2 mt-2">
               <div style="display: none">
                 <label class="block mb-1">Start Date:</label>
-                <input type="date" id="startDate-0" class="form-control w-36" />
+                <input
+                  type="date"
+                  id="startDate-0"
+                  class="form-control w-36"
+                  placeholder="Ex.: 2024-01-01"
+                />
               </div>
               <div style="display: none">
                 <label class="block mb-1">End Date:</label>
-                <input type="date" id="endDate-0" class="form-control w-36" />
+                <input
+                  type="date"
+                  id="endDate-0"
+                  class="form-control w-36"
+                  placeholder="Ex.: 2024-01-31"
+                />
               </div>
             </div>
             <div
@@ -140,7 +151,12 @@
               style="display: none"
             >
               <span>Fixing Date:</span>
-              <input type="date" id="fixDate1-0" class="form-control w-24" />
+              <input
+                type="date"
+                id="fixDate1-0"
+                class="form-control w-24"
+                placeholder="Ex.: 2024-02-01"
+              />
             </div>
             <label style="display: none"
               ><input type="checkbox" id="samePpt1-0" /> Use AVG PPT Date</label
@@ -204,17 +220,28 @@
                   type="date"
                   id="startDate2-0"
                   class="form-control w-36"
+                  placeholder="Ex.: 2024-01-01"
                 />
               </div>
               <div style="display: none">
                 <label class="block mb-1">End Date:</label>
-                <input type="date" id="endDate2-0" class="form-control w-36" />
+                <input
+                  type="date"
+                  id="endDate2-0"
+                  class="form-control w-36"
+                  placeholder="Ex.: 2024-01-31"
+                />
               </div>
             </div>
 
             <div class="flex items-center gap-2 mr-2" style="display: none">
               <span>Fixing Date:</span>
-              <input type="date" id="fixDate-0" class="form-control w-24" />
+              <input
+                type="date"
+                id="fixDate-0"
+                class="form-control w-24"
+                placeholder="Ex.: 2024-02-01"
+              />
             </div>
             <label style="display: none"
               ><input type="checkbox" id="samePpt2-0" /> Use AVG PPT Date</label


### PR DESCRIPTION
## Summary
- add helpful example placeholders to quantity and date inputs in the trade template

## Testing
- `npm test`
- manual check with jsdom to confirm placeholder text for additional trades

------
https://chatgpt.com/codex/tasks/task_e_684224a1c3cc832ebefe661da793752d