### PR TITLE
Add fade transitions when adding and removing trades

### DIFF
--- a/__tests__/clear-remove.test.js
+++ b/__tests__/clear-remove.test.js
@@ -46,14 +46,17 @@ test('clearTrade resets fields and output', () => {
 });
 
 test('removeTrade deletes block and renumbers remaining trades', () => {
+  jest.useFakeTimers();
   addTrade();
   addTrade();
 
   expect(document.querySelectorAll('.trade-title')[1].textContent).toBe('Trade 2');
 
   removeTrade(0);
+  jest.runAllTimers();
 
   expect(document.getElementById('trade-0')).toBeNull();
   const titles = Array.from(document.querySelectorAll('.trade-title')).map(el => el.textContent);
   expect(titles).toEqual(['Trade 1']);
+  jest.useRealTimers();
 });

--- a/main.js
+++ b/main.js
@@ -365,9 +365,12 @@ function clearTrade(index) {
 function removeTrade(index) {
   const trade = document.getElementById(`trade-${index}`);
   if (trade) {
-    trade.remove();
-    updateFinalOutput();
-    renumberTrades();
+    trade.classList.add("opacity-0", "transition-opacity", "duration-300");
+    setTimeout(() => {
+      trade.remove();
+      updateFinalOutput();
+      renumberTrades();
+    }, 300);
   }
 }
 
@@ -546,11 +549,12 @@ function addTrade() {
     .setAttribute("onclick", `removeTrade(${index})`);
   const div = document.createElement("div");
   div.id = `trade-${index}`;
-  div.className = "trade-block";
+  div.className = "trade-block opacity-0 transition-opacity duration-300";
   div.appendChild(clone);
   const trades = document.getElementById("trades");
   if (trades) {
     trades.appendChild(div);
+    requestAnimationFrame(() => div.classList.remove("opacity-0"));
   }
   const currentYear = new Date().getFullYear();
   populateYearOptions(`year1-${index}`, currentYear, 3);


### PR DESCRIPTION
## Summary
- animate trade cards when they are added or removed
- update tests for async removal

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684224df9c44832ea6040f32d8072a44