### PR TITLE
Add help modal with accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
             Copy All
           </button>
           <button onclick="shareWhatsApp()" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded w-32">WhatsApp</button>
+          <button onclick="openHelp()" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded w-32">Ajuda</button>
         </div>
       </div>
     </div>
@@ -244,6 +245,28 @@
         <p id="output-0" class="mt-2 font-mono text-sm"></p>
       </div>
     </template>
+
+    <div
+      id="help-modal"
+      class="hidden fixed inset-0 bg-black bg-opacity-50 items-center justify-center z-10"
+    >
+      <div class="bg-white p-6 rounded-lg max-w-lg mx-2" role="dialog" aria-modal="true">
+        <h2 class="text-xl font-semibold mb-4">Ajuda</h2>
+        <ul class="list-disc pl-5 space-y-2 text-sm">
+          <li><strong>Quantity (mt)</strong>: quantidade em toneladas.</li>
+          <li><strong>Price Type</strong>: escolha AVG, AVG Inter, Fix ou C2R.</li>
+          <li><strong>Start/End Date</strong>: usados apenas para AVG Inter.</li>
+          <li><strong>Fixing Date</strong>: obrigatório para tipos Fix e C2R.</li>
+          <li><strong>Use AVG PPT Date</strong>: usa o PPT do leg em AVG.</li>
+        </ul>
+        <button
+          onclick="closeHelp()"
+          class="mt-4 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+        >
+          Fechar
+        </button>
+      </div>
+    </div>
     <script src="solarlunar.min.js"></script>
     <script src="calendar-utils.js"></script>
     <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -519,6 +519,22 @@ function shareWhatsApp() {
   window.open(url, "_blank");
 }
 
+function openHelp() {
+  const modal = document.getElementById("help-modal");
+  if (modal) {
+    modal.classList.remove("hidden");
+    modal.classList.add("flex");
+  }
+}
+
+function closeHelp() {
+  const modal = document.getElementById("help-modal");
+  if (modal) {
+    modal.classList.add("hidden");
+    modal.classList.remove("flex");
+  }
+}
+
 function addTrade() {
   const index = nextIndex++;
   const template = document.getElementById("trade-template");
@@ -624,6 +640,8 @@ if (typeof module !== "undefined" && module.exports) {
     removeTrade,
     copyAll,
     shareWhatsApp,
+    openHelp,
+    closeHelp,
     setMinDates,
     updateEndDateMin,
     updateAvgRestrictions,


### PR DESCRIPTION
## Summary
- add "Ajuda" button near action controls
- include hidden help modal with instructions
- implement `openHelp` and `closeHelp` functions
- export the new functions for completeness

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684224f3fde4832eb5e073f31fc9b3f9