### PR TITLE
Implement Fix-vs-AVG validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,28 +30,17 @@ Make sure to visit the full path to `index.html` (not just `/`) because the serv
 Enter quantities as finite positive numbers. Values of zero or negative amounts
 will trigger an error message.
 
-When selecting the price type for Leg 1 you can choose **AVG Inter** to specify an averaging period. Pick a start and end date in the Leg 1 section and the request text will reflect that range.
+When selecting the price type for Leg 1 you can choose **AVG Period** to specify an averaging period. Pick a start and end date in the Leg 1 section and the request text will reflect that range.
 
-If one leg uses **Fix** pricing while the other uses **AVG**, a checkbox labeled
-"Use AVG PPT Date" appears next to the fixing date field on the fixed leg. When
-selected, this option fills that field with the averaging leg's second business
-day (its PPT date). Leg&nbsp;2's checkbox is visible when Leg&nbsp;1 is set to
-**AVG** and Leg&nbsp;2 is **Fix**. Likewise, Leg&nbsp;1's checkbox appears when
-Leg&nbsp;1 is **Fix** and Leg&nbsp;2 is **AVG**.
+If one leg uses **Fix** pricing while the other uses **AVG**, a checkbox labeled "Use AVG PPT Date" appears next to the fixing date field on the fixed leg. When selected, this option fills that field with the averaging leg's **last business day of the month**. The generated request then omits the fixing date and uses the averaging leg's PPT (second business day of the following month) for both sides. Leg&nbsp;2's checkbox is visible when Leg&nbsp;1 is set to **AVG** and Leg&nbsp;2 is **Fix**. Likewise, Leg&nbsp;1's checkbox appears when Leg&nbsp;1 is **Fix** and Leg&nbsp;2 is **AVG**.
 
-Only the leg priced as **Fix** shows this checkbox. When checked the generated
-request uses the averaging leg's PPT for that fixed leg and displays the date
-only on the fixed side. If you enter a specific fixing date instead, the request
-shows PPT dates for both legs (two business days after the fixing date for the
-fixed leg and the averaging leg's second business day of the following month).
+Only the leg priced as **Fix** shows this checkbox. When checked the generated request uses the averaging leg's PPT for that fixed leg and the fixing date does not appear in the text. If you enter a specific fixing date instead, the PPT still matches the averaging leg's PPT but the fixing date is shown before it.
 
 The Buy/Sell options of the two legs are synchronised: selecting **Buy** on Leg
 1 automatically selects **Sell** on Leg 2 and vice versa.
 
 Fixing date inputs only appear when a leg uses **Fix** pricing (Leg&nbsp;2 also
-shows it for **C2R**). When one leg is **AVG** and the other **Fix**, checking
-the "Use AVG PPT Date" option automatically fills the fixed leg's date with the
-averaging leg's PPT.
+shows it for **C2R (Cash)**). When one leg is **AVG** and the other **Fix**, checking the "Use AVG PPT Date" option automatically fills the fixed leg's date with the averaging leg's last business day.
 
 ## Building
 

--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -19,7 +19,7 @@ function setupDom() {
     <input id="qty-0" />
     <input type="radio" name="side1-0" value="buy" checked>
     <input type="radio" name="side1-0" value="sell">
-    <select id="type1-0"><option value="">Select</option><option value="AVG">AVG</option><option value="AVGInter">AVG Inter</option><option value="Fix">Fix</option><option value="C2R">C2R</option></select>
+    <select id="type1-0"><option value="">Select</option><option value="AVG">AVG</option><option value="AVGInter">AVG Period</option><option value="Fix">Fix</option><option value="C2R">C2R (Cash)</option></select>
     <select id="month1-0"><option>January</option><option>February</option><option>October</option></select>
     <select id="year1-0"><option>2025</option></select>
     <input id="startDate-0" type="date" />
@@ -29,7 +29,7 @@ function setupDom() {
     <input id="endDate2-0" type="date" />
     <input type="radio" name="side2-0" value="buy">
     <input type="radio" name="side2-0" value="sell" checked>
-    <select id="type2-0"><option value="">Select</option><option value="AVG">AVG</option><option value="AVGInter">AVG Inter</option><option value="Fix">Fix</option><option value="C2R">C2R</option></select>
+    <select id="type2-0"><option value="">Select</option><option value="AVG">AVG</option><option value="AVGInter">AVG Period</option><option value="Fix">Fix</option><option value="C2R">C2R (Cash)</option></select>
     <select id="month2-0"><option>February</option><option>October</option></select>
     <select id="year2-0"><option>2025</option></select>
     <input id="fixDate-0" />
@@ -64,7 +64,7 @@ describe("generateRequest", () => {
     generateRequest(0);
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe(
-      "LME Request: Buy 5 mt Al AVG January 2025 ppt 04/02/25 Flat and Sell 5 mt Al USD ppt 06/01/25 against",
+      "LME Request: Buy 5 mt Al AVG January 2025 ppt 04/02/25 Flat and Sell 5 mt Al USD 02/01/25, ppt 04/02/25 against",
     );
   });
 
@@ -147,6 +147,19 @@ describe("generateRequest", () => {
     generateRequest(0);
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe("Please provide a fixing date.");
+  });
+
+  test("rejects fix date after last business day", () => {
+    document.getElementById("qty-0").value = "5";
+    document.getElementById("type1-0").value = "AVG";
+    document.getElementById("type2-0").value = "Fix";
+    document.getElementById("month1-0").value = "January";
+    document.getElementById("year1-0").value = "2025";
+    document.getElementById("fixDate-0").value = "2025-02-02";
+    toggleLeg2Fields(0);
+    generateRequest(0);
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe("Fixing date must be on or before 31/01/25.");
   });
 });
 

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -10,6 +10,7 @@ document.getElementById('calendarType').value = 'gregorian';
 const {
   parseInputDate,
   getSecondBusinessDay,
+  getLastBusinessDay,
   getFixPpt,
   updateEndDateMin,
   updateAvgRestrictions,
@@ -36,6 +37,11 @@ describe('business day helpers', () => {
   test('getFixPpt computes two business days after fix date', () => {
     const res = getFixPpt('02/01/25');
     expect(res).toBe('06/01/25');
+  });
+
+  test('getLastBusinessDay finds month end', () => {
+    const res = getLastBusinessDay(2025, 0);
+    expect(res).toBe('31/01/25');
   });
 });
 

--- a/__tests__/toggle-fields.test.js
+++ b/__tests__/toggle-fields.test.js
@@ -10,7 +10,7 @@ document.getElementById("calendarType").value = "gregorian";
 const {
   toggleLeg1Fields,
   toggleLeg2Fields,
-  getSecondBusinessDay,
+  getLastBusinessDay,
 } = require("../main");
 
 beforeEach(() => {
@@ -61,8 +61,8 @@ test("Leg2 fields toggle and checkbox sets PPT", () => {
   expect(document.getElementById("samePpt1-0").parentElement.style.display).toBe(
     "none",
   );
-  const ppt = getSecondBusinessDay(2025, 0);
-  const date = calendarUtils.parseDateGregorian(ppt);
+  const last = getLastBusinessDay(2025, 0);
+  const date = calendarUtils.parseDateGregorian(last);
   expect(document.getElementById("fixDate-0").value).toBe(
     date.toISOString().split("T")[0],
   );

--- a/index.html
+++ b/index.html
@@ -104,9 +104,9 @@
               <select id="type1-0" class="form-control w-32">
                 <option value="">Select</option>
                 <option value="AVG">AVG</option>
-                <option value="AVGInter">AVG Inter</option>
+                <option value="AVGInter">AVG Period</option>
                 <option value="Fix">Fix</option>
-                <option value="C2R">C2R</option>
+                <option value="C2R">C2R (Cash)</option>
               </select>
             </div>
             <div class="flex gap-2" id="avgFields1-0" style="display: none">
@@ -191,9 +191,9 @@
               <select id="type2-0" class="form-control w-32">
                 <option value="">Select</option>
                 <option value="AVG">AVG</option>
-                <option value="AVGInter">AVG Inter</option>
+                <option value="AVGInter">AVG Period</option>
                 <option value="Fix">Fix</option>
-                <option value="C2R">C2R</option>
+                <option value="C2R">C2R (Cash)</option>
               </select>
             </div>
             <div class="flex gap-2" id="avgFields2-0" style="display: none">


### PR DESCRIPTION
## Summary
- rename price options to "AVG Period" and "C2R (Cash)"
- compute last business day helper
- validate Fix vs AVG trades and share PPT logic
- autopopulate fixing date with last business day when using AVG PPT date
- update help text in README
- adjust tests for new behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e1f7b9f0832e99a287d03f6fdbcb