### PR TITLE
Add trade confirmation modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,7 +221,7 @@
                 </select>
               </div>
             </div>
-              <div class="flex gap-2 mt-2">
+            <div class="flex gap-2 mt-2">
               <div style="display: none">
                 <label class="block mb-1">Start Date:</label>
                 <input
@@ -282,5 +282,25 @@
     <script src="solarlunar.min.js"></script>
     <script src="calendar-utils.js"></script>
     <script src="main.js"></script>
+
+    <div
+      id="confirm-modal"
+      class="fixed inset-0 bg-black bg-opacity-50 hidden items-center justify-center"
+    >
+      <div class="bg-white p-6 rounded shadow-lg max-w-md">
+        <p id="confirm-text" class="mb-4"></p>
+        <div class="flex justify-end gap-2">
+          <button id="confirm-cancel" class="bg-gray-300 px-4 py-2 rounded">
+            Cancelar
+          </button>
+          <button
+            id="confirm-ok"
+            class="bg-blue-600 text-white px-4 py-2 rounded"
+          >
+            Confirmar
+          </button>
+        </div>
+      </div>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add confirmation modal markup and styles
- add JS functions to build Portuguese summary and show modal
- call modal from trade generation button
- wire confirm/cancel handlers on load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842e92761b0832e9d53b312d5d8f3b0