### PR TITLE
Improve confirmation modal styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,11 +285,13 @@
 
     <div
       id="confirm-modal"
-      class="fixed inset-0 bg-black bg-opacity-50 hidden items-center justify-center"
+      class="fixed inset-0 bg-black/30 hidden z-50"
     >
-      <div class="bg-white p-6 rounded shadow-lg max-w-md">
-        <p id="confirm-text" class="mb-4"></p>
-        <div class="flex justify-end gap-2">
+      <div
+        class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-[#f0f8ff] border border-[#1e40af] p-6 rounded-lg shadow-lg w-full max-w-lg"
+      >
+        <p id="confirm-text" class="mb-4 text-center text-[16px]"></p>
+        <div class="flex justify-center gap-4">
           <button id="confirm-cancel" class="bg-gray-300 px-4 py-2 rounded">
             Cancelar
           </button>

--- a/main.js
+++ b/main.js
@@ -783,7 +783,7 @@ function openConfirmModal(index) {
     if (msg) msg.textContent = text;
     if (modal) {
       modal.classList.remove("hidden");
-      modal.classList.add("flex");
+      modal.classList.add("block");
     }
     pendingIndex = index;
   } catch (err) {
@@ -796,7 +796,7 @@ function closeConfirmModal() {
   const modal = document.getElementById("confirm-modal");
   if (modal) {
     modal.classList.add("hidden");
-    modal.classList.remove("flex");
+    modal.classList.remove("block");
   }
   pendingIndex = null;
 }


### PR DESCRIPTION
## Summary
- redesign confirmation modal style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842ee014da4832e9a5df5629d537a80