### PR TITLE
Restrict months when current year selected

### DIFF
--- a/__tests__/month-options.test.js
+++ b/__tests__/month-options.test.js
@@ -1,0 +1,72 @@
+/** @jest-environment jsdom */
+
+const { updateMonthOptions } = require('../main');
+
+describe('updateMonthOptions', () => {
+  test('hides past months when current year is selected', () => {
+    const currentYear = new Date().getFullYear();
+    document.body.innerHTML = `
+      <select id="month1-0">
+        <option>January</option>
+        <option>February</option>
+        <option>March</option>
+        <option>April</option>
+        <option>May</option>
+        <option>June</option>
+        <option>July</option>
+        <option>August</option>
+        <option>September</option>
+        <option>October</option>
+        <option>November</option>
+        <option>December</option>
+      </select>
+      <select id="year1-0">
+        <option>${currentYear}</option>
+        <option>${currentYear + 1}</option>
+      </select>`;
+    document.getElementById('year1-0').value = String(currentYear);
+    updateMonthOptions(0, 1);
+    const curMonth = new Date().getMonth();
+    const opts = document.getElementById('month1-0').options;
+    for (let i = 0; i < curMonth; i++) {
+      expect(opts[i].hidden).toBe(true);
+    }
+    for (let i = curMonth; i < opts.length; i++) {
+      expect(opts[i].hidden).toBe(false);
+    }
+
+    document.getElementById('year1-0').value = String(currentYear + 1);
+    updateMonthOptions(0, 1);
+    for (let i = 0; i < opts.length; i++) {
+      expect(opts[i].hidden).toBe(false);
+    }
+  });
+
+  test('selects next valid month when current selection becomes hidden', () => {
+    const currentYear = new Date().getFullYear();
+    const curMonth = new Date().getMonth();
+    document.body.innerHTML = `
+      <select id="month2-0">
+        <option>January</option>
+        <option>February</option>
+        <option>March</option>
+        <option>April</option>
+        <option>May</option>
+        <option>June</option>
+        <option>July</option>
+        <option>August</option>
+        <option>September</option>
+        <option>October</option>
+        <option>November</option>
+        <option>December</option>
+      </select>
+      <select id="year2-0">
+        <option>${currentYear}</option>
+      </select>`;
+    const monthSel = document.getElementById('month2-0');
+    monthSel.value = 'January';
+    updateMonthOptions(0, 2);
+    const expected = monthSel.options[Math.max(curMonth, 0)].textContent;
+    expect(monthSel.value).toBe(expected);
+  });
+});

--- a/main.js
+++ b/main.js
@@ -169,6 +169,38 @@ const monthNames = [
   "December",
 ];
 
+function updateMonthOptions(index, leg) {
+  const monthSel = document.getElementById(`month${leg}-${index}`);
+  const yearSel = document.getElementById(`year${leg}-${index}`);
+  if (!monthSel || !yearSel) return;
+  const currentYear = new Date().getFullYear();
+  const currentMonth = new Date().getMonth();
+  const selectedYear = parseInt(yearSel.value, 10);
+  const prev = monthSel.value;
+
+  Array.from(monthSel.options).forEach((opt, idx) => {
+    if (selectedYear === currentYear) {
+      opt.hidden = idx < currentMonth;
+    } else {
+      opt.hidden = false;
+    }
+  });
+
+  const valid = Array.from(monthSel.options).find(
+    (o) => !o.hidden && o.value === prev,
+  );
+  if (valid) {
+    monthSel.value = valid.value;
+  } else {
+    for (const opt of monthSel.options) {
+      if (!opt.hidden) {
+        monthSel.value = opt.value;
+        break;
+      }
+    }
+  }
+}
+
 function setMinDates(index) {
   const today = new Date().toISOString().split("T")[0];
   [
@@ -851,6 +883,8 @@ function addTrade() {
   const currentYear = new Date().getFullYear();
   populateYearOptions(`year1-${index}`, currentYear, 3);
   populateYearOptions(`year2-${index}`, currentYear, 3);
+  updateMonthOptions(index, 1);
+  updateMonthOptions(index, 2);
   setMinDates(index);
   updateEndDateMin(index, 1);
   updateEndDateMin(index, 2);
@@ -883,9 +917,15 @@ function addTrade() {
   const year1 = document.getElementById(`year1-${index}`);
   const year2 = document.getElementById(`year2-${index}`);
   if (year1)
-    year1.addEventListener("change", () => updateAvgRestrictions(index));
+    year1.addEventListener("change", () => {
+      updateMonthOptions(index, 1);
+      updateAvgRestrictions(index);
+    });
   if (year2)
-    year2.addEventListener("change", () => updateAvgRestrictions(index));
+    year2.addEventListener("change", () => {
+      updateMonthOptions(index, 2);
+      updateAvgRestrictions(index);
+    });
   toggleLeg1Fields(index);
   toggleLeg2Fields(index);
   document.querySelectorAll(`input[name='side1-${index}']`).forEach((r) => {
@@ -938,6 +978,7 @@ if (typeof module !== "undefined" && module.exports) {
     confirmModal,
     setMinDates,
     updateEndDateMin,
+    updateMonthOptions,
     updateAvgRestrictions,
   };
 }


### PR DESCRIPTION
## Summary
- limit selectable months to current month and later when the current year is chosen
- dynamically update month options when year changes
- preserve or reset selected month based on validity
- cover new behaviour with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842ef815a30832e823773a08ceb5dd4