### PR TITLE
Implement confirmation modal for trade requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,20 +284,23 @@
     <script src="main.js"></script>
 
     <div
-      id="confirm-modal"
-      class="fixed inset-0 bg-black/30 hidden z-50"
+      id="confirmation-modal"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 hidden"
     >
       <div
-        class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-[#f0f8ff] border border-[#1e40af] p-6 rounded-lg shadow-lg w-full max-w-lg"
+        class="bg-white rounded-xl shadow-xl p-6 max-w-xl w-full mx-4"
       >
-        <p id="confirm-text" class="mb-4 text-center text-[16px]"></p>
+        <p id="confirmation-text" class="mb-4 text-center text-[16px]"></p>
         <div class="flex justify-center gap-4">
-          <button id="confirm-cancel" class="bg-gray-300 px-4 py-2 rounded">
+          <button
+            id="confirmation-cancel"
+            class="bg-gray-300 px-4 py-2 rounded hover:bg-gray-100"
+          >
             Cancelar
           </button>
           <button
-            id="confirm-ok"
-            class="bg-blue-600 text-white px-4 py-2 rounded"
+            id="confirmation-ok"
+            class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
           >
             Confirmar
           </button>


### PR DESCRIPTION
## Summary
- add a modal popup to confirm trade actions
- update main.js to handle generic confirmation callbacks
- connect Generate buttons to show the confirmation modal
- update test and lint expectations

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842f17634d0832e98efb43ee1de9ec9