### PR TITLE
Fix PPT for AVG period vs AVG trades

### DIFF
--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -120,7 +120,22 @@ describe("generateRequest", () => {
     generateRequest(0);
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe(
-      "LME Request: Buy 5 mt Al Fixing AVG 01/09/25 to 10/09/25 and Sell 5 mt Al AVG October 2025 Flat against",
+      "LME Request: Buy 5 mt Al Fixing AVG 01/09/25 to 10/09/25, ppt 04/11/25 and Sell 5 mt Al AVG October 2025 Flat against",
+    );
+  });
+
+  test("creates AVG vs AVGInter text", () => {
+    document.getElementById("qty-0").value = "4";
+    document.getElementById("type1-0").value = "AVG";
+    document.getElementById("month1-0").value = "January";
+    document.getElementById("year1-0").value = "2025";
+    document.getElementById("type2-0").value = "AVGInter";
+    document.getElementById("startDate2-0").value = "2025-02-20";
+    document.getElementById("endDate2-0").value = "2025-02-25";
+    generateRequest(0);
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe(
+      "LME Request: Buy 4 mt Al AVG January 2025 Flat and Sell 4 mt Al Fixing AVG 20/02/25 to 25/02/25, ppt 04/02/25 against",
     );
   });
 

--- a/main.js
+++ b/main.js
@@ -343,10 +343,10 @@ function generateRequest(index) {
     const useSamePPT2 = document.getElementById(`samePpt2-${index}`)?.checked;
     // Determine which leg is averaging to compute its PPT
     let avgMonth, avgYear;
-    if (leg1Type.startsWith("AVG")) {
+    if (leg1Type === "AVG") {
       avgMonth = month;
       avgYear = year;
-    } else if (leg2Type.startsWith("AVG")) {
+    } else if (leg2Type === "AVG") {
       avgMonth = month2;
       avgYear = year2;
     }
@@ -360,9 +360,13 @@ function generateRequest(index) {
     const lastBizDate = lastBizDay ? parseDate(lastBizDay) : null;
 
     let leg1;
-    const showPptAvg =
+    const showPptAvgFix =
       (leg2Type === "Fix" && dateFix2Raw && !useSamePPT2) ||
       (leg1Type === "Fix" && dateFix1Raw && !useSamePPT1);
+    const showPptAvgInter =
+      (leg1Type === "AVGInter" && leg2Type === "AVG") ||
+      (leg2Type === "AVGInter" && leg1Type === "AVG");
+    const showPptAvg = showPptAvgFix || showPptAvgInter;
     if (leg1Type === "AVG") {
       leg1 = `${capitalize(leg1Side)} ${q} mt Al AVG ${month} ${year}`;
       leg1 += " Flat";
@@ -374,7 +378,7 @@ function generateRequest(index) {
       const startStr = formatDate(start);
       const endStr = formatDate(end);
       leg1 = `${capitalize(leg1Side)} ${q} mt Al Fixing AVG ${startStr} to ${endStr}`;
-      if (showPptAvg) leg1 += ` ppt ${pptDateAVG}`;
+      if (showPptAvg) leg1 += `${showPptAvgInter ? "," : ""} ppt ${pptDateAVG}`;
     } else if (leg1Type === "Fix" && leg2Type === "AVG") {
       if (useSamePPT1) {
         leg1 = `${capitalize(leg1Side)} ${q} mt Al USD ppt ${pptDateAVG}`;
@@ -416,7 +420,7 @@ function generateRequest(index) {
       const sStr = formatDate(start);
       const eStr = formatDate(end);
       leg2 = `${capitalize(leg2Side)} ${q} mt Al Fixing AVG ${sStr} to ${eStr}`;
-      if (showPptAvg) leg2 += ` ppt ${pptDateAVG}`;
+      if (showPptAvg) leg2 += `${showPptAvgInter ? "," : ""} ppt ${pptDateAVG}`;
     } else if (leg2Type === "Fix" && leg1Type === "AVG") {
       if (useSamePPT2) {
         leg2 = `${capitalize(leg2Side)} ${q} mt Al USD ppt ${pptDateAVG}`;
@@ -784,10 +788,10 @@ function buildConfirmationText(index) {
 
   let ppt = "";
   let avgMonth, avgYear;
-  if (type1.startsWith("AVG")) {
+  if (type1 === "AVG") {
     avgMonth = month1;
     avgYear = year1;
-  } else if (type2.startsWith("AVG")) {
+  } else if (type2 === "AVG") {
     avgMonth = month2;
     avgYear = year2;
   }


### PR DESCRIPTION
## Summary
- add PPT when averaging period is paired with monthly AVG
- compute PPT month only for monthly AVG legs
- update tests for new PPT text logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684359879bb4832eafe8d44bbf4d5ed3