### PR TITLE
Add company selection

### DIFF
--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -16,6 +16,8 @@ document.getElementById("calendarType").value = "gregorian";
 
 function setupDom() {
   document.body.innerHTML += `
+    <input type="radio" name="company" value="Alcast Brasil" checked>
+    <input type="radio" name="company" value="Alcast Trading">
     <input id="qty-0" />
     <input type="radio" name="side1-0" value="buy" checked>
     <input type="radio" name="side1-0" value="sell">
@@ -175,6 +177,16 @@ describe("generateRequest", () => {
     generateRequest(0);
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe("Fixing date must be on or before 31/01/25.");
+  });
+
+  test("final output includes selected company", () => {
+    document.getElementById("qty-0").value = "10";
+    document.getElementById("type2-0").value = "AVG";
+    generateRequest(0);
+    const finalOut = document.getElementById("final-output").value;
+    expect(finalOut).toBe(
+      "Alcast Brasil Request\nLME Request: Buy 10 mt Al AVG January 2025 Flat and Sell 10 mt Al AVG February 2025 Flat against"
+    );
   });
 });
 

--- a/index.html
+++ b/index.html
@@ -53,6 +53,27 @@
       <h1 class="text-3xl font-bold mb-6 text-center">
         LME Trade Request Generator
       </h1>
+      <div id="company-select" class="flex items-center gap-4 justify-center">
+        <label>
+          <input
+            type="radio"
+            name="company"
+            value="Alcast Brasil"
+            checked
+            class="mr-1"
+          />
+          Alcast Brasil
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="company"
+            value="Alcast Trading"
+            class="mr-1"
+          />
+          Alcast Trading
+        </label>
+      </div>
       <div id="trades" class="space-y-6"></div>
       <div class="space-y-2 bg-white p-6 rounded-lg shadow-md">
         <textarea

--- a/main.js
+++ b/main.js
@@ -508,11 +508,12 @@ function renumberTrades() {
 
 function updateFinalOutput() {
   const allOutputs = document.querySelectorAll("[id^='output-']");
-  const finalOutput = Array.from(allOutputs)
+  const lines = Array.from(allOutputs)
     .map((el) => el.textContent.trim())
-    .filter((t) => t)
-    .join("\n");
-  document.getElementById("final-output").value = finalOutput;
+    .filter((t) => t);
+  const company = document.querySelector("input[name='company']:checked")?.value;
+  if (company && lines.length) lines.unshift(`${company} Request`);
+  document.getElementById("final-output").value = lines.join("\n");
 }
 
 function syncLegSides(index, changedLeg) {
@@ -952,6 +953,9 @@ window.onload = () => {
     const cancel = document.getElementById("confirmation-cancel");
     if (ok) ok.addEventListener("click", confirmModal);
     if (cancel) cancel.addEventListener("click", cancelModal);
+    document
+      .querySelectorAll("input[name='company']")
+      .forEach((el) => el.addEventListener("change", updateFinalOutput));
   });
 };
 if ("serviceWorker" in navigator) {


### PR DESCRIPTION
## Summary
- add company selection radio buttons
- prefix final output with selected company
- update tests for new functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846eeed36b4832ea95e45cd22b60e8c