### PR TITLE
Sync PPT automatically when AVG is present

### DIFF
--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -35,8 +35,6 @@ function setupDom() {
     <select id="month2-0"><option>February</option><option>October</option></select>
     <select id="year2-0"><option>2025</option></select>
     <input id="fixDate-0" />
-    <input type="checkbox" id="samePpt1-0" />
-    <input type="checkbox" id="samePpt2-0" />
     <p id="output-0"></p>
     <textarea id="final-output"></textarea>
   `;
@@ -63,10 +61,11 @@ describe("generateRequest", () => {
     document.getElementById("qty-0").value = "5";
     document.getElementById("type2-0").value = "Fix";
     document.getElementById("fixDate-0").value = "2025-01-02";
+    toggleLeg2Fields(0);
     generateRequest(0);
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe(
-      "LME Request: Buy 5 mt Al AVG January 2025 Flat and Sell 5 mt Al USD 02/01/25, ppt 04/02/25 against",
+      "LME Request: Buy 5 mt Al AVG January 2025 Flat and Sell 5 mt Al USD ppt 04/02/25 against",
     );
   });
 
@@ -74,7 +73,6 @@ describe("generateRequest", () => {
     document.getElementById("qty-0").value = "8";
     document.getElementById("type1-0").value = "Fix";
     document.getElementById("type2-0").value = "AVG";
-    document.getElementById("samePpt1-0").checked = true;
     document.getElementById("month2-0").value = "February";
     document.getElementById("year2-0").value = "2025";
     toggleLeg1Fields(0);
@@ -89,7 +87,6 @@ describe("generateRequest", () => {
     document.getElementById("qty-0").value = "12";
     document.getElementById("type1-0").value = "AVG";
     document.getElementById("type2-0").value = "Fix";
-    document.getElementById("samePpt2-0").checked = true;
     document.getElementById("month1-0").value = "October";
     document.getElementById("year1-0").value = "2025";
     toggleLeg2Fields(0);
@@ -166,7 +163,7 @@ describe("generateRequest", () => {
     expect(out).toBe("Please provide a fixing date.");
   });
 
-  test("rejects fix date after last business day", () => {
+  test("ignores manual fix date when paired with AVG", () => {
     document.getElementById("qty-0").value = "5";
     document.getElementById("type1-0").value = "AVG";
     document.getElementById("type2-0").value = "Fix";
@@ -176,7 +173,9 @@ describe("generateRequest", () => {
     toggleLeg2Fields(0);
     generateRequest(0);
     const out = document.getElementById("output-0").textContent;
-    expect(out).toBe("Fixing date must be on or before 31/01/25.");
+    expect(out).toBe(
+      "LME Request: Buy 5 mt Al AVG January 2025 Flat and Sell 5 mt Al USD ppt 04/02/25 against",
+    );
   });
 
   test("final output includes selected company", () => {

--- a/__tests__/toggle-fields.test.js
+++ b/__tests__/toggle-fields.test.js
@@ -20,12 +20,10 @@ beforeEach(() => {
     <div id="startWrap"><input type="date" id="startDate-0"></div>
     <div id="endWrap"><input type="date" id="endDate-0"></div>
     <div id="fix1Wrap"><input type="date" id="fixDate1-0"></div>
-    <label id="sameWrap1"><input type="checkbox" id="samePpt1-0"></label>
     <select id="type2-0"><option value="">Select</option><option value="AVG">AVG</option><option value="Fix">Fix</option><option value="AVGInter">AVGInter</option><option value="C2R">C2R</option></select>
     <div id="startWrap2"><input type="date" id="startDate2-0"></div>
     <div id="endWrap2"><input type="date" id="endDate2-0"></div>
     <div id="fixWrap"><input type="date" id="fixDate-0"></div>
-    <label id="sameWrap2"><input type="checkbox" id="samePpt2-0"></label>
     <select id="month1-0"><option>January</option></select>
     <select id="year1-0"><option>2025</option></select>
     <select id="month2-0"><option>January</option></select>
@@ -47,23 +45,15 @@ test("Leg1 fix fields toggle with price type", () => {
   ).toBe("none");
 });
 
-test("Leg2 fields toggle and checkbox sets PPT", () => {
+test("Leg2 fields toggle autocompletes fix date", () => {
   document.getElementById("type1-0").value = "AVG";
   document.getElementById("type2-0").value = "Fix";
-  const chk = document.getElementById("samePpt2-0");
-  chk.checked = true;
   toggleLeg1Fields(0);
   toggleLeg2Fields(0);
-  expect(document.getElementById("fixDate-0").parentElement.style.display).toBe(
-    "",
-  );
-  expect(chk.parentElement.style.display).toBe("");
-  expect(document.getElementById("samePpt1-0").parentElement.style.display).toBe(
-    "none",
-  );
+  const input = document.getElementById("fixDate-0");
+  expect(input.parentElement.style.display).toBe("");
+  expect(input.readOnly).toBe(true);
   const last = getLastBusinessDay(2025, 0);
   const date = calendarUtils.parseDateGregorian(last);
-  expect(document.getElementById("fixDate-0").value).toBe(
-    date.toISOString().split("T")[0],
-  );
+  expect(input.value).toBe(date.toISOString().split("T")[0]);
 });

--- a/index.html
+++ b/index.html
@@ -209,9 +209,6 @@
                 aria-label="Fixing date for Leg 1"
               />
             </div>
-            <label style="display: none"
-              ><input type="checkbox" id="samePpt1-0" /> Use AVG PPT Date</label
-            >
           </div>
           <div>
             <h2 class="font-semibold">Leg 2</h2>
@@ -294,9 +291,6 @@
                 aria-label="Fixing date for Leg 2"
               />
             </div>
-            <label style="display: none"
-              ><input type="checkbox" id="samePpt2-0" /> Use AVG PPT Date</label
-            >
           </div>
         </div>
         <div class="flex flex-wrap items-center gap-2 justify-center">


### PR DESCRIPTION
## Summary
- remove obsolete "Use AVG PPT Date" checkbox
- auto-fill Fix leg dates from the AVG leg
- adjust request generation logic for new rules
- update confirmation message PPT logic
- revise tests for automatic PPT behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68470490b85c832ea6bc178b7dbd1113