### PR TITLE
Fix confirmation text ordering

### DIFF
--- a/__tests__/build-confirmation.test.js
+++ b/__tests__/build-confirmation.test.js
@@ -42,7 +42,7 @@ describe('buildConfirmationText', () => {
     document.getElementById('type2-0').value = 'Fix';
     const text = buildConfirmationText(0);
     expect(text).toBe(
-      'Você está comprando 5 toneladas de Al pela média de janeiro/2025, ppt 04/02/25, e vendendo 5 toneladas de Al com preço fixado. Confirma?'
+      'Você está comprando 5 toneladas de Al pela média de janeiro/2025, e vendendo 5 toneladas de Al com preço fixado, ppt 04/02/25. Confirma?'
     );
   });
 
@@ -53,6 +53,24 @@ describe('buildConfirmationText', () => {
     const text = buildConfirmationText(0);
     expect(text).toBe(
       'Você está comprando 3 toneladas de Al com preço fixado, ppt 04/03/25, e vendendo 3 toneladas de Al pela média de fevereiro/2025. Confirma?'
+    );
+  });
+
+  test('handles AVGInter versus Fix ordering', () => {
+    document.getElementById('qty-0').value = '5';
+    const typeSel = document.getElementById('type1-0');
+    typeSel.appendChild(new Option('AVGInter', 'AVGInter'));
+    typeSel.value = 'AVGInter';
+    document.getElementById('startDate-0').value = '2025-06-16';
+    document.getElementById('endDate-0').value = '2025-06-19';
+    document.getElementById('type2-0').value = 'Fix';
+    const fixInput = document.createElement('input');
+    fixInput.id = 'fixDate-0';
+    document.body.appendChild(fixInput);
+    document.getElementById('fixDate-0').value = '2025-06-19';
+    const text = buildConfirmationText(0);
+    expect(text).toBe(
+      'Você está comprando 5 toneladas de Al fixando a média de 16/06/25 a 19/06/25, e vendendo 5 toneladas de Al com preço fixado em 19/06/25, ppt 23/06/25. Confirma?'
     );
   });
 });

--- a/main.js
+++ b/main.js
@@ -720,9 +720,14 @@ function monthNamePt(m) {
   return idx >= 0 ? monthsPt[idx] : m;
 }
 
-function readableLeg(type, qty, start, end, month, year) {
+function readableLeg(type, qty, start, end, month, year, fix) {
   switch (type) {
     case "Fix":
+      if (fix) {
+        return `${qty} toneladas de Al com preço fixado em ${formatDate(
+          parseInputDate(fix),
+        )}`;
+      }
       return `${qty} toneladas de Al com preço fixado`;
     case "C2R":
       return `${qty} toneladas de Al com preço fixo em dinheiro`;
@@ -751,6 +756,8 @@ function generateConfirmationMessage(trade) {
     year2,
     side1,
     side2,
+    fix1,
+    fix2,
   } = trade;
 
   let pptDate = "";
@@ -772,8 +779,12 @@ function generateConfirmationMessage(trade) {
   const sideStr1 = side1 === "buy" ? "comprando" : "vendendo";
   const sideStr2 = side2 === "sell" ? "vendendo" : "comprando";
 
-  const leg1 = readableLeg(type1, qty, start1, end1, month1, year1);
-  const leg2 = readableLeg(type2, qty, start2, end2, month2, year2);
+  const leg1 = readableLeg(type1, qty, start1, end1, month1, year1, fix1);
+  const leg2 = readableLeg(type2, qty, start2, end2, month2, year2, fix2);
+
+  if (type2 === "Fix" && type1 !== "Fix") {
+    return `Você está ${sideStr1} ${leg1}, e ${sideStr2} ${leg2}, ppt ${pptDate}. Confirma?`;
+  }
 
   return `Você está ${sideStr1} ${leg1}, ppt ${pptDate}, e ${sideStr2} ${leg2}. Confirma?`;
 }
@@ -797,6 +808,8 @@ function buildConfirmationText(index) {
     end1: document.getElementById(`endDate-${index}`)?.value,
     start2: document.getElementById(`startDate2-${index}`)?.value,
     end2: document.getElementById(`endDate2-${index}`)?.value,
+    fix1: document.getElementById(`fixDate1-${index}`)?.value,
+    fix2: document.getElementById(`fixDate-${index}`)?.value,
   };
 
   return generateConfirmationMessage(trade);


### PR DESCRIPTION
## Summary
- allow readableLeg to include fixing date
- move PPT date after Fix leg in confirmation message
- support fix dates in confirmation text builder
- test AVGInter vs Fix scenario
- adjust existing confirmation tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684708ad08c0832eaea45f711a6f061a