### PR TITLE
Ensure Fix leg precedes AVG leg

### DIFF
--- a/__tests__/build-confirmation.test.js
+++ b/__tests__/build-confirmation.test.js
@@ -42,7 +42,7 @@ describe('buildConfirmationText', () => {
     document.getElementById('type2-0').value = 'Fix';
     const text = buildConfirmationText(0);
     expect(text).toBe(
-      'Você está comprando 5 toneladas de Al pela média de janeiro/2025, e vendendo 5 toneladas de Al com preço fixado, ppt 04/02/25. Confirma?'
+      'Você está vendendo 5 toneladas de Al com preço fixado, ppt 04/02/25, e comprando 5 toneladas de Al pela média de janeiro/2025. Confirma?'
     );
   });
 
@@ -70,7 +70,7 @@ describe('buildConfirmationText', () => {
     document.getElementById('fixDate-0').value = '2025-06-19';
     const text = buildConfirmationText(0);
     expect(text).toBe(
-      'Você está comprando 5 toneladas de Al fixando a média de 16/06/25 a 19/06/25, e vendendo 5 toneladas de Al com preço fixado em 19/06/25, ppt 23/06/25. Confirma?'
+      'Você está vendendo 5 toneladas de Al com preço fixado em 19/06/25, ppt 23/06/25, e comprando 5 toneladas de Al fixando a média de 16/06/25 a 19/06/25. Confirma?'
     );
   });
 });

--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -65,7 +65,7 @@ describe("generateRequest", () => {
     generateRequest(0);
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe(
-      "LME Request: Buy 5 mt Al AVG January 2025 Flat and Sell 5 mt Al USD ppt 04/02/25 against",
+      "LME Request: Sell 5 mt Al USD ppt 04/02/25 and Buy 5 mt Al AVG January 2025 Flat against",
     );
   });
 
@@ -93,7 +93,7 @@ describe("generateRequest", () => {
     generateRequest(0);
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe(
-      "LME Request: Buy 12 mt Al AVG October 2025 Flat and Sell 12 mt Al USD ppt 04/11/25 against",
+      "LME Request: Sell 12 mt Al USD ppt 04/11/25 and Buy 12 mt Al AVG October 2025 Flat against",
     );
   });
 
@@ -104,7 +104,7 @@ describe("generateRequest", () => {
     generateRequest(0);
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe(
-      "LME Request: Buy 7 mt Al AVG January 2025 Flat and Sell 7 mt Al C2R 02/01/25 ppt 06/01/25 against",
+      "LME Request: Sell 7 mt Al C2R 02/01/25 ppt 06/01/25 and Buy 7 mt Al AVG January 2025 Flat against",
     );
   });
 
@@ -174,7 +174,7 @@ describe("generateRequest", () => {
     generateRequest(0);
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe(
-      "LME Request: Buy 5 mt Al AVG January 2025 Flat and Sell 5 mt Al USD ppt 04/02/25 against",
+      "LME Request: Sell 5 mt Al USD ppt 04/02/25 and Buy 5 mt Al AVG January 2025 Flat against",
     );
   });
 

--- a/main.js
+++ b/main.js
@@ -442,7 +442,20 @@ function generateRequest(index) {
       leg2 = `${capitalize(leg2Side)} ${q} mt Al C2R ${dateFix2} ppt ${pptFix}`;
     }
 
-    const result = `LME Request: ${leg1} and ${leg2} against`;
+    const fixTypes = ["Fix", "C2R"];
+    const avgTypes = ["AVG", "AVGInter", "AVGPeriod"];
+    let firstLeg = leg1;
+    let secondLeg = leg2;
+    if (
+      fixTypes.includes(leg2Type) &&
+      avgTypes.includes(leg1Type) &&
+      !fixTypes.includes(leg1Type)
+    ) {
+      firstLeg = leg2;
+      secondLeg = leg1;
+    }
+
+    const result = `LME Request: ${firstLeg} and ${secondLeg} against`;
     if (outputEl) outputEl.textContent = result;
     updateFinalOutput();
   } catch (e) {
@@ -782,11 +795,34 @@ function generateConfirmationMessage(trade) {
   const leg1 = readableLeg(type1, qty, start1, end1, month1, year1, fix1);
   const leg2 = readableLeg(type2, qty, start2, end2, month2, year2, fix2);
 
-  if (type2 === "Fix" && type1 !== "Fix") {
-    return `Você está ${sideStr1} ${leg1}, e ${sideStr2} ${leg2}, ppt ${pptDate}. Confirma?`;
+  const fixTypes = ["Fix", "C2R"];
+  const avgTypes = ["AVG", "AVGInter", "AVGPeriod"];
+
+  let firstLeg = leg1;
+  let secondLeg = leg2;
+  let firstSide = sideStr1;
+  let secondSide = sideStr2;
+  let firstType = type1;
+  let secondType = type2;
+
+  if (
+    fixTypes.includes(type2) &&
+    avgTypes.includes(type1) &&
+    !fixTypes.includes(type1)
+  ) {
+    firstLeg = leg2;
+    secondLeg = leg1;
+    firstSide = sideStr2;
+    secondSide = sideStr1;
+    firstType = type2;
+    secondType = type1;
   }
 
-  return `Você está ${sideStr1} ${leg1}, ppt ${pptDate}, e ${sideStr2} ${leg2}. Confirma?`;
+  if (fixTypes.includes(secondType) && !fixTypes.includes(firstType)) {
+    return `Você está ${firstSide} ${firstLeg}, e ${secondSide} ${secondLeg}, ppt ${pptDate}. Confirma?`;
+  }
+
+  return `Você está ${firstSide} ${firstLeg}, ppt ${pptDate}, e ${secondSide} ${secondLeg}. Confirma?`;
 }
 
 function buildConfirmationText(index) {


### PR DESCRIPTION
## Summary
- prioritize Fix/C2R legs before AVG or AVG Period legs when generating request text
- reorder confirmation message for Fix/C2R vs AVG combinations
- update tests for new ordering logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68470ec14820832eb30ecb6ce4b7b263