### PR TITLE
Add Forward trade option and sync PPT

### DIFF
--- a/__tests__/build-confirmation.test.js
+++ b/__tests__/build-confirmation.test.js
@@ -11,6 +11,8 @@ const { buildConfirmationText } = require('../main');
 
 function setupDom() {
   document.body.innerHTML += `
+    <select id="tradeType-0"><option value="Swap">Swap</option><option value="Forward">Forward</option></select>
+    <input type="checkbox" id="syncPpt-0">
     <input id="qty-0" />
     <input type="radio" name="side1-0" value="buy" checked>
     <input type="radio" name="side1-0" value="sell">

--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -18,11 +18,13 @@ function setupDom() {
   document.body.innerHTML += `
     <input type="radio" name="company" value="Alcast Brasil" checked>
     <input type="radio" name="company" value="Alcast Trading">
+    <select id="tradeType-0"><option value="Swap">Swap</option><option value="Forward">Forward</option></select>
+    <input type="checkbox" id="syncPpt-0">
     <input id="qty-0" />
     <input type="radio" name="side1-0" value="buy" checked>
     <input type="radio" name="side1-0" value="sell">
     <select id="type1-0"><option value="">Select</option><option value="AVG">AVG</option><option value="AVGInter">AVG Period</option><option value="Fix">Fix</option><option value="C2R">C2R (Cash)</option></select>
-    <select id="month1-0"><option>January</option><option>February</option><option>October</option></select>
+    <select id="month1-0"><option>January</option><option>February</option><option>July</option><option>October</option></select>
     <select id="year1-0"><option>2025</option></select>
     <input id="startDate-0" type="date" />
     <input id="endDate-0" type="date" />
@@ -32,7 +34,7 @@ function setupDom() {
     <input type="radio" name="side2-0" value="buy">
     <input type="radio" name="side2-0" value="sell" checked>
     <select id="type2-0"><option value="">Select</option><option value="AVG">AVG</option><option value="AVGInter">AVG Period</option><option value="Fix">Fix</option><option value="C2R">C2R (Cash)</option></select>
-    <select id="month2-0"><option>February</option><option>October</option></select>
+    <select id="month2-0"><option>February</option><option>July</option><option>October</option></select>
     <select id="year2-0"><option>2025</option></select>
     <input id="fixDate-0" />
     <p id="output-0"></p>
@@ -175,6 +177,36 @@ describe("generateRequest", () => {
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe(
       "LME Request: Sell 5 mt Al USD ppt 04/02/25 and Buy 5 mt Al AVG January 2025 Flat against",
+    );
+  });
+
+  test("creates single leg forward AVG request", () => {
+    document.getElementById("tradeType-0").value = "Forward";
+    document.getElementById("qty-0").value = "6";
+    document.getElementById("type1-0").value = "AVG";
+    document.getElementById("month1-0").value = "January";
+    document.getElementById("year1-0").value = "2025";
+    generateRequest(0);
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe("LME Request: Buy 6 mt Al AVG January 2025 Flat (AVG)");
+  });
+
+  test("forward with two legs sync PPT", () => {
+    document.getElementById("tradeType-0").value = "Forward";
+    document.querySelector("input[name='side2-0'][value='buy']").checked = true;
+    document.getElementById("qty-0").value = "5";
+    document.getElementById("type1-0").value = "AVGInter";
+    document.getElementById("startDate-0").value = "2025-05-16";
+    document.getElementById("endDate-0").value = "2025-05-19";
+    document.getElementById("type2-0").value = "AVG";
+    document.getElementById("month2-0").value = "July";
+    document.getElementById("year2-0").value = "2025";
+    document.getElementById("syncPpt-0").checked = true;
+    generateRequest(0);
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe(
+      "LME Request: Buy 5 mt Al Fixing AVG 16/05/25 to 19/05/25, ppt 04/08/25 (AVG Period)\n" +
+        "LME Request: Buy 5 mt Al AVG July 2025 Flat (AVG)"
     );
   });
 

--- a/index.html
+++ b/index.html
@@ -125,6 +125,16 @@
             aria-label="Quantity in metric tons"
           />
         </div>
+        <div class="flex items-center gap-4 flex-wrap">
+          <label class="font-medium">Trade Type:</label>
+          <select id="tradeType-0" class="form-control w-32">
+            <option value="Swap" selected>Swap</option>
+            <option value="Forward">Forward</option>
+          </select>
+          <label class="flex items-center">
+            <input type="checkbox" id="syncPpt-0" class="mr-1" /> Syncronize PPT
+          </label>
+        </div>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
             <h2 class="font-semibold">Leg 1</h2>

--- a/main.js
+++ b/main.js
@@ -316,6 +316,9 @@ function generateRequest(index) {
       return;
     }
     qtyInput.classList.remove("border-red-500");
+    const tradeType =
+      document.getElementById(`tradeType-${index}`)?.value || "Swap";
+    const syncPpt = document.getElementById(`syncPpt-${index}`)?.checked;
     const leg1Side = document.querySelector(
       `input[name='side1-${index}']:checked`,
     ).value;
@@ -358,6 +361,7 @@ function generateRequest(index) {
     const lastBizDate = lastBizDay ? parseDate(lastBizDay) : null;
 
     let leg1;
+    let ppt1 = "";
     const showPptAvgFix =
       (leg2Type === "Fix" && dateFix2Raw && !fixInput.readOnly) ||
       (leg1Type === "Fix" && dateFix1Raw && !(fixInputLeg1 && fixInputLeg1.readOnly));
@@ -367,7 +371,7 @@ function generateRequest(index) {
     const showPptAvg = showPptAvgFix || showPptAvgInter;
     if (leg1Type === "AVG") {
       leg1 = `${capitalize(leg1Side)} ${q} mt Al AVG ${month} ${year}`;
-      leg1 += " Flat";
+      leg1 += tradeType === "Forward" ? " Flat (AVG)" : " Flat";
     } else if (leg1Type === "AVGInter") {
       const start = parseInputDate(startDateRaw);
       const end = parseInputDate(endDateRaw);
@@ -376,14 +380,20 @@ function generateRequest(index) {
       const startStr = formatDate(start);
       const endStr = formatDate(end);
       leg1 = `${capitalize(leg1Side)} ${q} mt Al Fixing AVG ${startStr} to ${endStr}`;
-      if (showPptAvg) leg1 += `${showPptAvgInter ? "," : ""} ppt ${pptDateAVG}`;
+      ppt1 = pptDateAVG;
+      if (showPptAvg) {
+        leg1 += `${showPptAvgInter ? "," : ""} ppt ${ppt1}`;
+        if (tradeType === "Forward") leg1 += " (AVG Period)";
+      }
     } else if (leg1Type === "Fix" && leg2Type === "AVG") {
-      leg1 = `${capitalize(leg1Side)} ${q} mt Al USD ppt ${pptDateAVG}`;
+      ppt1 = pptDateAVG;
+      leg1 = `${capitalize(leg1Side)} ${q} mt Al USD ppt ${ppt1}`;
     } else if (leg1Type === "Fix" && leg2Type === "AVGInter") {
       const end = parseInputDate(document.getElementById(`endDate2-${index}`)?.value || "");
       if (!end) throw new Error("End date is required for AVG Period.");
       const ppt = getFixPpt(formatDate(end));
-      leg1 = `${capitalize(leg1Side)} ${q} mt Al USD ppt ${ppt}`;
+      ppt1 = ppt;
+      leg1 = `${capitalize(leg1Side)} ${q} mt Al USD ppt ${ppt1}`;
     } else if (leg1Type === "Fix") {
       if (!dateFix1Raw) throw new Error("Please provide a fixing date.");
       let pptFixLeg1;
@@ -393,14 +403,16 @@ function generateRequest(index) {
         err.fixInputId = `fixDate1-${index}`;
         throw err;
       }
-      leg1 = `${capitalize(leg1Side)} ${q} mt Al USD ${dateFix1}, ppt ${pptFixLeg1}`;
+      ppt1 = pptFixLeg1;
+      leg1 = `${capitalize(leg1Side)} ${q} mt Al USD ${dateFix1}, ppt ${ppt1}`;
     } else {
       leg1 = `${capitalize(leg1Side)} ${q} mt Al ${leg1Type}`;
     }
     let leg2;
+    let ppt2 = "";
     if (leg2Type === "AVG") {
       leg2 = `${capitalize(leg2Side)} ${q} mt Al AVG ${month2} ${year2}`;
-      leg2 += " Flat";
+      leg2 += tradeType === "Forward" ? " Flat (AVG)" : " Flat";
     } else if (leg2Type === "AVGInter") {
       const start = parseInputDate(
         document.getElementById(`startDate2-${index}`)?.value || "",
@@ -413,14 +425,20 @@ function generateRequest(index) {
       const sStr = formatDate(start);
       const eStr = formatDate(end);
       leg2 = `${capitalize(leg2Side)} ${q} mt Al Fixing AVG ${sStr} to ${eStr}`;
-      if (showPptAvg) leg2 += `${showPptAvgInter ? "," : ""} ppt ${pptDateAVG}`;
+      ppt2 = pptDateAVG;
+      if (showPptAvg) {
+        leg2 += `${showPptAvgInter ? "," : ""} ppt ${ppt2}`;
+        if (tradeType === "Forward") leg2 += " (AVG Period)";
+      }
     } else if (leg2Type === "Fix" && leg1Type === "AVG") {
-      leg2 = `${capitalize(leg2Side)} ${q} mt Al USD ppt ${pptDateAVG}`;
+      ppt2 = pptDateAVG;
+      leg2 = `${capitalize(leg2Side)} ${q} mt Al USD ppt ${ppt2}`;
     } else if (leg2Type === "Fix" && leg1Type === "AVGInter") {
       const end = parseInputDate(document.getElementById(`endDate-${index}`)?.value || "");
       if (!end) throw new Error("End date is required for AVG Period.");
       const ppt = getFixPpt(formatDate(end));
-      leg2 = `${capitalize(leg2Side)} ${q} mt Al USD ppt ${ppt}`;
+      ppt2 = ppt;
+      leg2 = `${capitalize(leg2Side)} ${q} mt Al USD ppt ${ppt2}`;
     } else if (leg2Type === "Fix") {
       if (!dateFix2Raw) throw new Error("Please provide a fixing date.");
       let pptFix;
@@ -430,7 +448,8 @@ function generateRequest(index) {
         err.fixInputId = `fixDate-${index}`;
         throw err;
       }
-      leg2 = `${capitalize(leg2Side)} ${q} mt Al USD ${dateFix2}, ppt ${pptFix}`;
+      ppt2 = pptFix;
+      leg2 = `${capitalize(leg2Side)} ${q} mt Al USD ${dateFix2}, ppt ${ppt2}`;
     } else if (leg2Type === "C2R") {
       let pptFix;
       try {
@@ -439,7 +458,8 @@ function generateRequest(index) {
         err.fixInputId = `fixDate-${index}`;
         throw err;
       }
-      leg2 = `${capitalize(leg2Side)} ${q} mt Al C2R ${dateFix2} ppt ${pptFix}`;
+      ppt2 = pptFix;
+      leg2 = `${capitalize(leg2Side)} ${q} mt Al C2R ${dateFix2} ppt ${ppt2}`;
     }
 
     const fixTypes = ["Fix", "C2R"];
@@ -455,7 +475,24 @@ function generateRequest(index) {
       secondLeg = leg1;
     }
 
-    const result = `LME Request: ${firstLeg} and ${secondLeg} against`;
+    let result;
+    if (tradeType === "Swap") {
+      result = `LME Request: ${firstLeg} and ${secondLeg} against`;
+    } else {
+      if (secondLeg) {
+        if (syncPpt && ppt1 && ppt2) {
+          const d1 = parseDate(ppt1);
+          const d2 = parseDate(ppt2);
+          let latest = ppt1;
+          if (d1 && d2 && d2 > d1) latest = ppt2;
+          firstLeg = firstLeg.replace(ppt1, latest);
+          secondLeg = secondLeg.replace(ppt2, latest);
+        }
+        result = `LME Request: ${firstLeg}\nLME Request: ${secondLeg}`;
+      } else {
+        result = `LME Request: ${firstLeg}`;
+      }
+    }
     if (outputEl) outputEl.textContent = result;
     updateFinalOutput();
   } catch (e) {


### PR DESCRIPTION
## Summary
- introduce `Trade Type` dropdown with Forward and Swap options
- allow synchronizing PPT dates when creating a Forward
- adjust request generation logic for Forward trades
- update HTML template and tests for the new functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684764280dd8832e8c37e999e85c3471