### PR TITLE
Hide Price Type output in trade requests

### DIFF
--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -188,7 +188,7 @@ describe("generateRequest", () => {
     document.getElementById("year1-0").value = "2025";
     generateRequest(0);
     const out = document.getElementById("output-0").textContent;
-    expect(out).toBe("LME Request: Buy 6 mt Al AVG January 2025 Flat (AVG)");
+    expect(out).toBe("LME Request: Buy 6 mt Al AVG January 2025 Flat");
   });
 
   test("forward with two legs sync PPT", () => {
@@ -205,8 +205,8 @@ describe("generateRequest", () => {
     generateRequest(0);
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe(
-      "LME Request: Buy 5 mt Al Fixing AVG 16/05/25 to 19/05/25, ppt 04/08/25 (AVG Period)\n" +
-        "LME Request: Buy 5 mt Al AVG July 2025 Flat (AVG)"
+      "LME Request: Buy 5 mt Al Fixing AVG 16/05/25 to 19/05/25, ppt 04/08/25\n" +
+        "LME Request: Buy 5 mt Al AVG July 2025 Flat"
     );
   });
 

--- a/index.html
+++ b/index.html
@@ -152,11 +152,10 @@
               ><input type="radio" name="side1-0" value="sell" class="mr-1" />
               Sell</label
             ><br />
-            <div class="flex items-center gap-2 mt-2 mb-2">
+            <div class="flex items-center gap-2 mt-2 mb-2" style="display: none">
               <label class="font-medium">Price Type:</label>
               <select id="type1-0" class="form-control w-32">
-                <option value="">Select</option>
-                <option value="AVG">AVG</option>
+                <option value="AVG" selected>AVG</option>
                 <option value="AVGInter">AVG Period</option>
                 <option value="Fix">Fix</option>
                 <option value="C2R">C2R (Cash)</option>
@@ -236,11 +235,10 @@
               ><input type="radio" name="side2-0" value="sell" class="mr-1" />
               Sell</label
             ><br />
-            <div class="flex items-center gap-2 mt-2 mb-2">
+            <div class="flex items-center gap-2 mt-2 mb-2" style="display: none">
               <label class="font-medium">Price Type:</label>
               <select id="type2-0" class="form-control w-32">
-                <option value="">Select</option>
-                <option value="AVG">AVG</option>
+                <option value="AVG" selected>AVG</option>
                 <option value="AVGInter">AVG Period</option>
                 <option value="Fix">Fix</option>
                 <option value="C2R">C2R (Cash)</option>

--- a/main.js
+++ b/main.js
@@ -371,7 +371,7 @@ function generateRequest(index) {
     const showPptAvg = showPptAvgFix || showPptAvgInter;
     if (leg1Type === "AVG") {
       leg1 = `${capitalize(leg1Side)} ${q} mt Al AVG ${month} ${year}`;
-      leg1 += tradeType === "Forward" ? " Flat (AVG)" : " Flat";
+      leg1 += " Flat";
     } else if (leg1Type === "AVGInter") {
       const start = parseInputDate(startDateRaw);
       const end = parseInputDate(endDateRaw);
@@ -383,7 +383,6 @@ function generateRequest(index) {
       ppt1 = pptDateAVG;
       if (showPptAvg) {
         leg1 += `${showPptAvgInter ? "," : ""} ppt ${ppt1}`;
-        if (tradeType === "Forward") leg1 += " (AVG Period)";
       }
     } else if (leg1Type === "Fix" && leg2Type === "AVG") {
       ppt1 = pptDateAVG;
@@ -412,7 +411,7 @@ function generateRequest(index) {
     let ppt2 = "";
     if (leg2Type === "AVG") {
       leg2 = `${capitalize(leg2Side)} ${q} mt Al AVG ${month2} ${year2}`;
-      leg2 += tradeType === "Forward" ? " Flat (AVG)" : " Flat";
+      leg2 += " Flat";
     } else if (leg2Type === "AVGInter") {
       const start = parseInputDate(
         document.getElementById(`startDate2-${index}`)?.value || "",
@@ -428,7 +427,6 @@ function generateRequest(index) {
       ppt2 = pptDateAVG;
       if (showPptAvg) {
         leg2 += `${showPptAvgInter ? "," : ""} ppt ${ppt2}`;
-        if (tradeType === "Forward") leg2 += " (AVG Period)";
       }
     } else if (leg2Type === "Fix" && leg1Type === "AVG") {
       ppt2 = pptDateAVG;


### PR DESCRIPTION
## Summary
- stop showing Price Type text in generated requests
- adjust tests for new output

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68476986f088832ebdc963d955f94930