### PR TITLE
Restore Price Type fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,10 +152,11 @@
               ><input type="radio" name="side1-0" value="sell" class="mr-1" />
               Sell</label
             ><br />
-            <div class="flex items-center gap-2 mt-2 mb-2" style="display: none">
+            <div class="flex items-center gap-2 mt-2 mb-2">
               <label class="font-medium">Price Type:</label>
               <select id="type1-0" class="form-control w-32">
-                <option value="AVG" selected>AVG</option>
+                <option value="">Select</option>
+                <option value="AVG">AVG</option>
                 <option value="AVGInter">AVG Period</option>
                 <option value="Fix">Fix</option>
                 <option value="C2R">C2R (Cash)</option>
@@ -235,10 +236,11 @@
               ><input type="radio" name="side2-0" value="sell" class="mr-1" />
               Sell</label
             ><br />
-            <div class="flex items-center gap-2 mt-2 mb-2" style="display: none">
+            <div class="flex items-center gap-2 mt-2 mb-2">
               <label class="font-medium">Price Type:</label>
               <select id="type2-0" class="form-control w-32">
-                <option value="AVG" selected>AVG</option>
+                <option value="">Select</option>
+                <option value="AVG">AVG</option>
                 <option value="AVGInter">AVG Period</option>
                 <option value="Fix">Fix</option>
                 <option value="C2R">C2R (Cash)</option>


### PR DESCRIPTION
## Summary
- re-expose Price Type selectors in the trade form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68476e60a27c832ea2fa4ab5fd05372a