### PR TITLE
Add order validity field to trade form

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,6 +298,19 @@ button[name="generate"]:active {
                   </select>
                 </div>
 
+                <div id="validityField1-0" class="flex items-center gap-2" style="display: none">
+                  <label class="text-sm font-medium whitespace-nowrap">Order Validity:</label>
+                  <select id="orderValidity1-0" class="form-control" style="max-width: 150px; height: 2.5rem; font-size: 0.875rem; padding: 0.375rem 0.5rem;">
+                    <option value="">Select</option>
+                    <option value="Day">Day (valid until market close)</option>
+                    <option value="GTC">GTC (Good Till Cancelled)</option>
+                    <option value="3 Hours">3 Hours</option>
+                    <option value="6 Hours">6 Hours</option>
+                    <option value="12 Hours">12 Hours</option>
+                    <option value="Until Further Notice">Until Further Notice</option>
+                  </select>
+                </div>
+
                 <!-- Campo Limit corrigido -->
                 <div id="limitField1-0" style="display: none">
                   <label class="block mb-1 text-xs font-medium">Limit Price ($):</label>
@@ -443,6 +456,19 @@ button[name="generate"]:active {
                     <option value="Limit">Limit</option>
                     <option value="Range">Range</option>
                     <option value="Resting">Resting</option>
+                  </select>
+                </div>
+
+                <div id="validityField2-0" class="flex items-center gap-2" style="display: none">
+                  <label class="text-sm font-medium whitespace-nowrap">Order Validity:</label>
+                  <select id="orderValidity2-0" class="form-control" style="max-width: 150px; height: 2.5rem; font-size: 0.875rem; padding: 0.375rem 0.5rem;">
+                    <option value="">Select</option>
+                    <option value="Day">Day (valid until market close)</option>
+                    <option value="GTC">GTC (Good Till Cancelled)</option>
+                    <option value="3 Hours">3 Hours</option>
+                    <option value="6 Hours">6 Hours</option>
+                    <option value="12 Hours">12 Hours</option>
+                    <option value="Until Further Notice">Until Further Notice</option>
                   </select>
                 </div>
 


### PR DESCRIPTION
## Summary
- support specifying `Order Validity` per leg
- show validity options when order type isn't `At Market`
- incorporate validity text in generated trade request
- default to `Day` when no option is chosen
- handle date parsing with two‑digit years
- improve month option and date restriction helpers
- ensure PPT date adds two business days
- update company header output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684de7a43ef8832e97ac230fcf003e84