### PR TITLE
Update tests for Execution Instruction

### DIFF
--- a/__tests__/build-confirmation.test.js
+++ b/__tests__/build-confirmation.test.js
@@ -75,4 +75,38 @@ describe('buildConfirmationText', () => {
       'Você está vendendo 5 toneladas de Al com preço fixado em 19/06/25, ppt 23/06/25, e comprando 5 toneladas de Al fixando a média de 16/06/25 a 19/06/25. Confirma?'
     );
   });
+
+  test('includes order type text for Limit', () => {
+    document.getElementById('qty-0').value = '2';
+    document.getElementById('type1-0').value = 'Fix';
+    const fixInput = document.createElement('input');
+    fixInput.id = 'fixDate-0';
+    document.body.appendChild(fixInput);
+    document.getElementById('fixDate-0').value = '2025-01-05';
+    const orderSel = document.createElement('select');
+    orderSel.id = 'orderType1-0';
+    orderSel.innerHTML = `<option value="Limit" selected>Limit</option>`;
+    document.body.appendChild(orderSel);
+    const price = document.createElement('input');
+    price.id = 'limitPrice1-0';
+    price.value = '2300';
+    document.body.appendChild(price);
+    const text = buildConfirmationText(0);
+    expect(text).toContain('Limit 2300');
+  });
+
+  test('includes order type text for Resting', () => {
+    document.getElementById('qty-0').value = '1';
+    document.getElementById('type1-0').value = 'Fix';
+    const fixInput = document.createElement('input');
+    fixInput.id = 'fixDate-0';
+    document.body.appendChild(fixInput);
+    document.getElementById('fixDate-0').value = '2025-01-05';
+    const orderSel = document.createElement('select');
+    orderSel.id = 'orderType1-0';
+    orderSel.innerHTML = `<option value="Resting" selected>Resting</option>`;
+    document.body.appendChild(orderSel);
+    const text = buildConfirmationText(0);
+    expect(text).toContain('Resting');
+  });
 });

--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -210,14 +210,42 @@ describe("generateRequest", () => {
     );
   });
 
-  test("final output includes selected company", () => {
+  test("final output includes new execution header", () => {
     document.getElementById("qty-0").value = "10";
     document.getElementById("type2-0").value = "AVG";
     generateRequest(0);
     const finalOut = document.getElementById("final-output").value;
     expect(finalOut).toBe(
-      "Alcast Brasil Request\nLME Request: Buy 10 mt Al AVG January 2025 Flat and Sell 10 mt Al AVG February 2025 Flat against"
+      "Alcast Brasil Execution Instruction\nLME Request: Buy 10 mt Al AVG January 2025 Flat and Sell 10 mt Al AVG February 2025 Flat against"
     );
+  });
+
+  test("adds execution block for Limit order", () => {
+    document.getElementById("qty-0").value = "4";
+    document.getElementById("type2-0").value = "Fix";
+    const orderType = document.createElement("select");
+    orderType.id = "orderType2-0";
+    orderType.innerHTML = `<option value=\"Limit\" selected>Limit</option>`;
+    document.body.appendChild(orderType);
+    const limit = document.createElement("input");
+    limit.id = "limitPrice2-0";
+    limit.value = "2500";
+    document.body.appendChild(limit);
+    generateRequest(0);
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toContain("Limit 2500");
+  });
+
+  test("adds execution block for Resting order", () => {
+    document.getElementById("qty-0").value = "2";
+    document.getElementById("type2-0").value = "Fix";
+    const orderType = document.createElement("select");
+    orderType.id = "orderType2-0";
+    orderType.innerHTML = `<option value=\"Resting\" selected>Resting</option>`;
+    document.body.appendChild(orderType);
+    generateRequest(0);
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toContain("Resting");
   });
 });
 


### PR DESCRIPTION
## Summary
- update generate-request tests for new Execution Instruction header
- add Limit and Resting cases for request generation
- expand confirmation tests with Limit and Resting orders

## Testing
- `npm test` *(fails: build-confirmation.test.js and generate-request.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684df43d265c832eb40575dd72944aa5