### PR TITLE
Update header for execution instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Only the leg priced as **Fix** shows this checkbox. When checked the generated r
 The Buy/Sell options of the two legs are synchronised: selecting **Buy** on Leg
 1 automatically selects **Sell** on Leg 2 and vice versa.
 
+Selecting a company at the top of the page also adds a header to the final text
+area. Depending on the choice, the first line will be either **Alcast Brasil
+Execution Instruction** or **Alcast Trading Execution Instruction**.
+
 Fixing date inputs only appear when a leg uses **Fix** pricing (Leg&nbsp;2 also
 shows it for **C2R (Cash)**). When one leg is **AVG** and the other **Fix**, checking the "Use AVG PPT Date" option automatically fills the fixed leg's date with the averaging leg's last business day.
 

--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -244,7 +244,7 @@ describe("generateRequest", () => {
     generateRequest(0);
     const finalOut = document.getElementById("final-output").value;
     expect(finalOut).toBe(
-      "For Alcast Brasil Account -\nLME Request: Buy 10 mt Al AVG January 2025 Flat and Sell 10 mt Al AVG February 2025 Flat against"
+      "Alcast Brasil Execution Instruction\nLME Request: Buy 10 mt Al AVG January 2025 Flat and Sell 10 mt Al AVG February 2025 Flat against"
     );
   });
 });

--- a/main.js
+++ b/main.js
@@ -1331,9 +1331,9 @@ function updateFinalOutput() {
     .filter((t) => t);
   
   const company = document.querySelector("input[name='company']:checked")?.value;
-  
+
   if (company && lines.length) {
-    lines.unshift(`For ${company} Account -`);
+    lines.unshift(`${company} Execution Instruction`);
   }
   
   document.getElementById("final-output").value = lines.join("\n");
@@ -1536,8 +1536,8 @@ function sendEmail() {
   let cleanText = text;
   if (company) {
     const companyHeaders = [
-      "For Alcast Brasil Account -",
-      "For Alcast Trading Account -"
+      "Alcast Brasil Execution Instruction",
+      "Alcast Trading Execution Instruction"
     ];
     
     companyHeaders.forEach(header => {
@@ -1553,7 +1553,7 @@ function sendEmail() {
   
   if (company) {
     emailSubject = `LME Trade Request - ${company}`;
-    emailBody = `For ${company} Account – please quote the following trade request:\n\n`;
+    emailBody = `${company} Execution Instruction – please quote the following trade request:\n\n`;
   } else {
     emailBody = "Please quote the following trade request:\n\n";
   }


### PR DESCRIPTION
## Summary
- change final output header to "Alcast Brasil Execution Instruction" or "Alcast Trading Execution Instruction"
- adjust email header logic
- document new header in README
- update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df905dbc0832e88e237da1118c97a