### PR TITLE
Add order type to confirmation text

### DIFF
--- a/__tests__/build-confirmation.test.js
+++ b/__tests__/build-confirmation.test.js
@@ -92,7 +92,7 @@ describe('buildConfirmationText', () => {
     document.body.appendChild(validity);
     const text = buildConfirmationText(0);
     expect(text).toBe(
-      'Você está comprando 3 toneladas de Al com preço fixado, ppt 04/02/25, e vendendo 3 toneladas de Al pela média de janeiro/2025.\nOrdem resting (melhor oferta no book) válida por 3 horas. Confirma?'
+      'Você está comprando 3 toneladas de Al com preço fixado Resting, valid for 3 Hours, ppt 04/02/25, e vendendo 3 toneladas de Al pela média de janeiro/2025.\nOrdem resting (melhor oferta no book) válida por 3 horas. Confirma?'
     );
   });
 });

--- a/main.js
+++ b/main.js
@@ -439,6 +439,8 @@ function buildConfirmationText(index) {
     limitPrice2: document.getElementById(`limitPrice2-${index}`)?.value,
     validity1: document.getElementById(`orderValidity1-${index}`)?.value,
     validity2: document.getElementById(`orderValidity2-${index}`)?.value,
+    orderText1: getOrderTypeText ? getOrderTypeText(index, 1) : "",
+    orderText2: getOrderTypeText ? getOrderTypeText(index, 2) : "",
   };
 
   return generateConfirmationMessage(trade);
@@ -467,6 +469,8 @@ function generateConfirmationMessage(trade) {
     limitPrice2,
     validity1,
     validity2,
+    orderText1,
+    orderText2,
   } = trade;
 
   let pptDate = "";
@@ -488,8 +492,8 @@ function generateConfirmationMessage(trade) {
   const sideStr1 = side1 === "buy" ? "comprando" : "vendendo";
   const sideStr2 = side2 === "sell" ? "vendendo" : "comprando";
 
-  const leg1 = readableLeg(type1, qty, start1, end1, month1, year1, fix1);
-  const leg2 = readableLeg(type2, qty, start2, end2, month2, year2, fix2);
+  const leg1 = readableLeg(type1, qty, start1, end1, month1, year1, fix1, orderText1);
+  const leg2 = readableLeg(type2, qty, start2, end2, month2, year2, fix2, orderText2);
 
   const fixTypes = ["Fix", "C2R"];
   const avgTypes = ["AVG", "AVGInter", "AVGPeriod"];
@@ -544,17 +548,19 @@ function generateConfirmationMessage(trade) {
   return `${baseLine} Confirma?`;
 }
 
-function readableLeg(type, qty, start, end, month, year, fix) {
+function readableLeg(type, qty, start, end, month, year, fix, orderText = "") {
   switch (type) {
     case "Fix":
       if (fix) {
-        return `${qty} toneladas de Al com preço fixado em ${formatDate(
+        let base = `${qty} toneladas de Al com preço fixado em ${formatDate(
           parseInputDate(fix),
         )}`;
+        if (orderText) base += orderText;
+        return base;
       }
-      return `${qty} toneladas de Al com preço fixado`;
+      return `${qty} toneladas de Al com preço fixado${orderText}`;
     case "C2R":
-      return `${qty} toneladas de Al com preço fixo em dinheiro`;
+      return `${qty} toneladas de Al com preço fixo em dinheiro${orderText}`;
     case "AVG":
       return `${qty} toneladas de Al pela média de ${monthNamePt(month).toLowerCase()}/${year}`;
     case "AVGInter":


### PR DESCRIPTION
## Summary
- include order type text when building confirmation messages
- update `readableLeg` helper to append order text
- adapt confirmation unit test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684df9084710832eafb76e60341e199f