### PR TITLE
Allow limit/resting fix orders without date

### DIFF
--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -208,6 +208,61 @@ describe("generateRequest", () => {
     );
   });
 
+  test("allows missing fixing date for limit orders", () => {
+    document.getElementById("qty-0").value = "5";
+    document.getElementById("type1-0").value = "Fix";
+    document.getElementById("fixDate1-0").value = "2025-01-02";
+    document.getElementById("type2-0").value = "Fix";
+    document.getElementById("fixDate-0").value = "";
+
+    const ot = document.createElement("select");
+    ot.id = "orderType2-0";
+    ot.innerHTML = '<option value="Limit" selected>Limit</option>';
+    document.body.appendChild(ot);
+
+    const ov = document.createElement("select");
+    ov.id = "orderValidity2-0";
+    ov.innerHTML = '<option value="Day" selected>Day</option>';
+    document.body.appendChild(ov);
+
+    const lp = document.createElement("input");
+    lp.id = "limitPrice2-0";
+    lp.value = "2500";
+    document.body.appendChild(lp);
+
+    generateRequest(0);
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe(
+      "LME Request: Buy 5 mt Al USD 02/01/25, ppt 06/01/25 and Sell 5 mt Al USD Limit 2500, valid for Day against\n" +
+        "Execution Instruction: Please work this order as a Limit @ USD 2500 for the Sell side, valid for Day."
+    );
+  });
+
+  test("allows missing fixing date for resting orders", () => {
+    document.getElementById("qty-0").value = "4";
+    document.getElementById("type1-0").value = "Fix";
+    document.getElementById("fixDate1-0").value = "2025-01-02";
+    document.getElementById("type2-0").value = "Fix";
+    document.getElementById("fixDate-0").value = "";
+
+    const ot = document.createElement("select");
+    ot.id = "orderType2-0";
+    ot.innerHTML = '<option value="Resting" selected>Resting</option>';
+    document.body.appendChild(ot);
+
+    const ov = document.createElement("select");
+    ov.id = "orderValidity2-0";
+    ov.innerHTML = '<option value="Day" selected>Day</option>';
+    document.body.appendChild(ov);
+
+    generateRequest(0);
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe(
+      "LME Request: Buy 4 mt Al USD 02/01/25, ppt 06/01/25 and Sell 4 mt Al USD Resting, valid for Day against\n" +
+        "Execution Instruction: Please work this order posting as the best bid/offer in the book for the Sell side, valid for Day."
+    );
+  });
+
   test("creates single leg forward AVG request", () => {
     document.getElementById("tradeType-0").value = "Forward";
     document.getElementById("qty-0").value = "6";

--- a/main.js
+++ b/main.js
@@ -737,19 +737,26 @@ function generateRequest(index) {
       leg1 = `${capitalize(leg1Side)} ${q} mt Al USD${orderTypeText} ppt ${ppt1}`;
       
     } else if (leg1Type === "Fix") {
-      if (!dateFix1Raw) throw new Error("Please provide a fixing date.");
-      let pptFixLeg1;
-      try {
-        pptFixLeg1 = getFixPpt(dateFix1);
-      } catch (err) {
-        err.fixInputId = `fixDate1-${index}`;
-        throw err;
-      }
-      ppt1 = pptFixLeg1;
-      
-      // ADICIONAR: Order Type para Fix
+      // Determine order type details first so we know if fixing date is required
       const orderTypeText = getOrderTypeText ? getOrderTypeText(index, 1) : "";
-      leg1 = `${capitalize(leg1Side)} ${q} mt Al USD ${dateFix1}${orderTypeText}, ppt ${ppt1}`;
+      const isLimitOrResting = /\b(Limit|Resting)/.test(orderTypeText);
+      if (!dateFix1Raw && !isLimitOrResting)
+        throw new Error("Please provide a fixing date.");
+
+      if (dateFix1Raw) {
+        let pptFixLeg1;
+        try {
+          pptFixLeg1 = getFixPpt(dateFix1);
+        } catch (err) {
+          err.fixInputId = `fixDate1-${index}`;
+          throw err;
+        }
+        ppt1 = pptFixLeg1;
+        leg1 = `${capitalize(leg1Side)} ${q} mt Al USD ${dateFix1}${orderTypeText}, ppt ${ppt1}`;
+      } else {
+        // No fixing date provided but allowed for Limit/Resting orders
+        leg1 = `${capitalize(leg1Side)} ${q} mt Al USD${orderTypeText}`;
+      }
       
     } else {
       leg1 = `${capitalize(leg1Side)} ${q} mt Al ${leg1Type}`;
@@ -795,33 +802,44 @@ function generateRequest(index) {
       leg2 = `${capitalize(leg2Side)} ${q} mt Al USD${orderTypeText} ppt ${ppt2}`;
       
     } else if (leg2Type === "Fix") {
-      if (!dateFix2Raw) throw new Error("Please provide a fixing date.");
-      let pptFix;
-      try {
-        pptFix = getFixPpt(dateFix2);
-      } catch (err) {
-        err.fixInputId = `fixDate-${index}`;
-        throw err;
-      }
-      ppt2 = pptFix;
-      
-      // ADICIONAR: Order Type para Fix
       const orderTypeText = getOrderTypeText ? getOrderTypeText(index, 2) : "";
-      leg2 = `${capitalize(leg2Side)} ${q} mt Al USD ${dateFix2}${orderTypeText}, ppt ${ppt2}`;
+      const isLimitOrResting = /\b(Limit|Resting)/.test(orderTypeText);
+      if (!dateFix2Raw && !isLimitOrResting)
+        throw new Error("Please provide a fixing date.");
+
+      if (dateFix2Raw) {
+        let pptFix;
+        try {
+          pptFix = getFixPpt(dateFix2);
+        } catch (err) {
+          err.fixInputId = `fixDate-${index}`;
+          throw err;
+        }
+        ppt2 = pptFix;
+        leg2 = `${capitalize(leg2Side)} ${q} mt Al USD ${dateFix2}${orderTypeText}, ppt ${ppt2}`;
+      } else {
+        leg2 = `${capitalize(leg2Side)} ${q} mt Al USD${orderTypeText}`;
+      }
       
     } else if (leg2Type === "C2R") {
-      if (!dateFix2Raw) throw new Error("Please provide a fixing date.");
-      let pptFix;
-      try {
-        pptFix = getFixPpt(dateFix2);
-      } catch (err) {
-        err.fixInputId = `fixDate-${index}`;
-        throw err;
-      }
-      ppt2 = pptFix;
-
       const orderTypeText = getOrderTypeText ? getOrderTypeText(index, 2) : "";
-      leg2 = `${capitalize(leg2Side)} ${q} mt Al C2R${orderTypeText} ${dateFix2} ppt ${pptFix}`;
+      const isLimitOrResting = /\b(Limit|Resting)/.test(orderTypeText);
+      if (!dateFix2Raw && !isLimitOrResting)
+        throw new Error("Please provide a fixing date.");
+
+      if (dateFix2Raw) {
+        let pptFix;
+        try {
+          pptFix = getFixPpt(dateFix2);
+        } catch (err) {
+          err.fixInputId = `fixDate-${index}`;
+          throw err;
+        }
+        ppt2 = pptFix;
+        leg2 = `${capitalize(leg2Side)} ${q} mt Al C2R${orderTypeText} ${dateFix2} ppt ${pptFix}`;
+      } else {
+        leg2 = `${capitalize(leg2Side)} ${q} mt Al C2R${orderTypeText}`;
+      }
     }
 
     const fixTypes = ["Fix", "C2R"];


### PR DESCRIPTION
## Summary
- relax fixing date requirement when limit or resting order types are selected
- keep order type text in request output even when no fixing date is entered
- cover the new scenarios in generateRequest tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df90bab24832e93622d29df35c03a