### PR TITLE
Strip validity from order leg text

### DIFF
--- a/__tests__/build-confirmation.test.js
+++ b/__tests__/build-confirmation.test.js
@@ -92,7 +92,7 @@ describe('buildConfirmationText', () => {
     document.body.appendChild(validity);
     const text = buildConfirmationText(0);
     expect(text).toBe(
-      'Você está comprando 3 toneladas de Al com preço fixado Resting, valid for 3 Hours, ppt 04/02/25, e vendendo 3 toneladas de Al pela média de janeiro/2025.\nOrdem resting (melhor oferta no book) válida por 3 horas. Confirma?'
+      'Você está comprando 3 toneladas de Al com preço fixado Resting, ppt 04/02/25, e vendendo 3 toneladas de Al pela média de janeiro/2025.\nOrdem resting (melhor oferta no book) válida por 3 horas. Confirma?'
     );
   });
 });

--- a/main.js
+++ b/main.js
@@ -435,8 +435,16 @@ function buildConfirmationText(index) {
     limitPrice2: document.getElementById(`limitPrice2-${index}`)?.value,
     validity1: document.getElementById(`orderValidity1-${index}`)?.value,
     validity2: document.getElementById(`orderValidity2-${index}`)?.value,
-    orderText1: getOrderTypeText ? getOrderTypeText(index, 1) : "",
-    orderText2: getOrderTypeText ? getOrderTypeText(index, 2) : "",
+    orderText1: (() => {
+      const rawText = getOrderTypeText ? getOrderTypeText(index, 1) : "";
+      const cleanText = rawText.replace(/, valid (?:for|until)[^,]*/i, "");
+      return cleanText;
+    })(),
+    orderText2: (() => {
+      const rawText = getOrderTypeText ? getOrderTypeText(index, 2) : "";
+      const cleanText = rawText.replace(/, valid (?:for|until)[^,]*/i, "");
+      return cleanText;
+    })(),
   };
 
   return generateConfirmationMessage(trade);


### PR DESCRIPTION
## Summary
- scrub validity from order type text used in confirmation legs
- update confirmation tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68500a3153dc832e8d651a72a1f0c2bb