### PR TITLE
Handle resting fix orders with AVG legs

### DIFF
--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -263,6 +263,60 @@ describe("generateRequest", () => {
     );
   });
 
+  test("adds ppt for AVG leg when opposite fix is resting", () => {
+    document.getElementById("qty-0").value = "5";
+    document.getElementById("type1-0").value = "Fix";
+    document.getElementById("type2-0").value = "AVG";
+    document.getElementById("month2-0").value = "February";
+    document.getElementById("year2-0").value = "2025";
+    document.getElementById("fixDate1-0").value = "";
+
+    const ot = document.createElement("select");
+    ot.id = "orderType1-0";
+    ot.innerHTML = '<option value="Resting" selected>Resting</option>';
+    document.body.appendChild(ot);
+
+    const ov = document.createElement("select");
+    ov.id = "orderValidity1-0";
+    ov.innerHTML = '<option value="Day" selected>Day</option>';
+    document.body.appendChild(ov);
+
+    toggleLeg1Fields(0);
+    generateRequest(0);
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe(
+      "LME Request: Buy 5 mt Al USD Resting, valid for Day ppt 04/03/25 and Sell 5 mt Al AVG February 2025 Flat, ppt 04/03/25 against\n" +
+        "Execution Instruction: Please work this order posting as the best bid/offer in the book for the Buy side, valid for Day."
+    );
+  });
+
+  test("adds ppt for AVG leg1 when second fix is resting", () => {
+    document.getElementById("qty-0").value = "5";
+    document.getElementById("type1-0").value = "AVG";
+    document.getElementById("month1-0").value = "January";
+    document.getElementById("year1-0").value = "2025";
+    document.getElementById("type2-0").value = "Fix";
+    document.getElementById("fixDate-0").value = "";
+
+    const ot = document.createElement("select");
+    ot.id = "orderType2-0";
+    ot.innerHTML = '<option value="Resting" selected>Resting</option>';
+    document.body.appendChild(ot);
+
+    const ov = document.createElement("select");
+    ov.id = "orderValidity2-0";
+    ov.innerHTML = '<option value="Day" selected>Day</option>';
+    document.body.appendChild(ov);
+
+    toggleLeg2Fields(0);
+    generateRequest(0);
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe(
+      "LME Request: Sell 5 mt Al USD Resting, valid for Day ppt 04/02/25 and Buy 5 mt Al AVG January 2025 Flat, ppt 04/02/25 against\n" +
+        "Execution Instruction: Please work this order posting as the best bid/offer in the book for the Sell side, valid for Day."
+    );
+  });
+
   test("creates single leg forward AVG request", () => {
     document.getElementById("tradeType-0").value = "Forward";
     document.getElementById("qty-0").value = "6";

--- a/main.js
+++ b/main.js
@@ -668,6 +668,10 @@ function generateRequest(index) {
     const leg2Type = document.getElementById(`type2-${index}`).value;
     const month2 = document.getElementById(`month2-${index}`).value;
     const year2 = parseInt(document.getElementById(`year2-${index}`).value);
+    const orderType1 =
+      document.getElementById(`orderType1-${index}`)?.value || "";
+    const orderType2 =
+      document.getElementById(`orderType2-${index}`)?.value || "";
     const fixInputLeg1 = document.getElementById(`fixDate1-${index}`);
     const fixInput = document.getElementById(`fixDate-${index}`);
     const dateFix1Raw = fixInputLeg1 ? fixInputLeg1.value : "";
@@ -695,8 +699,14 @@ function generateRequest(index) {
     let leg1;
     let ppt1 = "";
     const showPptAvgFix =
-      (leg2Type === "Fix" && dateFix2Raw && !fixInput.readOnly) ||
-      (leg1Type === "Fix" && dateFix1Raw && !(fixInputLeg1 && fixInputLeg1.readOnly));
+      (leg2Type === "Fix" &&
+        ((dateFix2Raw && !fixInput.readOnly) || orderType2 === "Resting")) ||
+      (leg1Type === "Fix" &&
+        ((dateFix1Raw && !(fixInputLeg1 && fixInputLeg1.readOnly)) ||
+          orderType1 === "Resting"));
+    const showPptAvgFixResting =
+      (leg2Type === "Fix" && leg1Type === "AVG" && orderType2 === "Resting") ||
+      (leg1Type === "Fix" && leg2Type === "AVG" && orderType1 === "Resting");
     const showPptAvgInter =
       (leg1Type === "AVGInter" && leg2Type === "AVG") ||
       (leg2Type === "AVGInter" && leg1Type === "AVG");
@@ -706,6 +716,9 @@ function generateRequest(index) {
       leg1 = `${capitalize(leg1Side)} ${q} mt Al AVG ${month} ${year}`;
       leg1 += ` Flat`;
       ppt1 = pptDateAVG;
+      if (showPptAvgFixResting && leg2Type === "Fix") {
+        leg1 += `, ppt ${ppt1}`;
+      }
     } else if (leg1Type === "AVGInter") {
       const start = parseInputDate(startDateRaw);
       const end = parseInputDate(endDateRaw);
@@ -767,6 +780,9 @@ function generateRequest(index) {
       leg2 = `${capitalize(leg2Side)} ${q} mt Al AVG ${month2} ${year2}`;
       leg2 += ` Flat`;
       ppt2 = pptDateAVG;
+      if (showPptAvgFixResting && leg1Type === "Fix") {
+        leg2 += `, ppt ${ppt2}`;
+      }
     } else if (leg2Type === "AVGInter") {
       const start = parseInputDate(
         document.getElementById(`startDate2-${index}`)?.value || "",


### PR DESCRIPTION
## Summary
- capture order type for each leg in `generateRequest`
- flag when AVG leg is opposite a resting Fix order
- display PPT date on AVG leg when paired with a resting Fix
- extend tests for resting Fix against AVG legs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68500a2ee9c4832ebe4efbe8bb64b33c