### PR TITLE
Update tests for fixed price wording and PPT

### DIFF
--- a/__tests__/build-confirmation.test.js
+++ b/__tests__/build-confirmation.test.js
@@ -92,7 +92,7 @@ describe('buildConfirmationText', () => {
     document.body.appendChild(validity);
     const text = buildConfirmationText(0);
     expect(text).toBe(
-      'Você está comprando 3 toneladas de Al com preço fixado Resting, valid for 3 Hours, ppt 04/02/25, e vendendo 3 toneladas de Al pela média de janeiro/2025.\nOrdem resting (melhor oferta no book) válida por 3 horas. Confirma?'
+      'Você está comprando 3 toneladas de Al com preço fixado Resting, ppt 04/02/25, e vendendo 3 toneladas de Al pela média de janeiro/2025.\nOrdem resting (melhor oferta no book) válida por 3 horas. Confirma?'
     );
   });
 });

--- a/__tests__/generate-request.test.js
+++ b/__tests__/generate-request.test.js
@@ -204,7 +204,7 @@ describe("generateRequest", () => {
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe(
       "LME Request: Sell 5 mt Al USD Limit 2300, valid for Day ppt 04/02/25 and Buy 5 mt Al AVG January 2025 Flat against\n" +
-        "Execution Instruction: Please work this order as a Limit @ USD 2300 for the Sell side, valid for Day."
+        "Execution Instruction: Please work this order as a Limit @ USD 2300 for the Fixed price, valid for Day."
     );
   });
 
@@ -234,7 +234,7 @@ describe("generateRequest", () => {
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe(
       "LME Request: Buy 5 mt Al USD 02/01/25, ppt 06/01/25 and Sell 5 mt Al USD Limit 2500, valid for Day against\n" +
-        "Execution Instruction: Please work this order as a Limit @ USD 2500 for the Sell side, valid for Day."
+        "Execution Instruction: Please work this order as a Limit @ USD 2500 for the Fixed price, valid for Day."
     );
   });
 
@@ -259,7 +259,33 @@ describe("generateRequest", () => {
     const out = document.getElementById("output-0").textContent;
     expect(out).toBe(
       "LME Request: Buy 4 mt Al USD 02/01/25, ppt 06/01/25 and Sell 4 mt Al USD Resting, valid for Day against\n" +
-        "Execution Instruction: Please work this order posting as the best bid/offer in the book for the Sell side, valid for Day."
+        "Execution Instruction: Please work this order posting as the best bid/offer in the book for the Fixed price, valid for Day."
+    );
+  });
+
+  test("shows PPT on AVG leg with resting order", () => {
+    document.getElementById("qty-0").value = "5";
+    document.getElementById("type1-0").value = "AVG";
+    document.getElementById("type2-0").value = "Fix";
+    document.getElementById("month1-0").value = "January";
+    document.getElementById("year1-0").value = "2025";
+    document.getElementById("fixDate-0").value = "";
+
+    const ot = document.createElement("select");
+    ot.id = "orderType2-0";
+    ot.innerHTML = '<option value="Resting" selected>Resting</option>';
+    document.body.appendChild(ot);
+
+    const ov = document.createElement("select");
+    ov.id = "orderValidity2-0";
+    ov.innerHTML = '<option value="Day" selected>Day</option>';
+    document.body.appendChild(ov);
+
+    generateRequest(0);
+    const out = document.getElementById("output-0").textContent;
+    expect(out).toBe(
+      "LME Request: Sell 5 mt Al USD Resting, valid for Day ppt 04/02/25 and Buy 5 mt Al AVG January 2025 Flat ppt 04/02/25 against\n" +
+        "Execution Instruction: Please work this order posting as the best bid/offer in the book for the Fixed price, valid for Day."
     );
   });
 


### PR DESCRIPTION
## Summary
- update execution instruction wording for Limit/Resting orders
- strip validity from confirmation order type text
- show PPT on AVG leg when paired with Resting order
- adjust tests for new wording and PPT behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68500a332388832eb4bfe4168f1b450f